### PR TITLE
Use __thread for compatibility with gcc <= 4.7.

### DIFF
--- a/fesvr/context.cc
+++ b/fesvr/context.cc
@@ -2,7 +2,7 @@
 #include <assert.h>
 #include <sched.h>
 
-static thread_local context_t* cur;
+static __thread context_t* cur;
 
 context_t::context_t()
   : creator(NULL), func(NULL), arg(NULL),


### PR DESCRIPTION
Use __thread in place of thread_local.  This is necessary to compile using gcc
version 4.7.2, the version of gcc present in Debian stable (wheezy).
