### PR TITLE
enable width to be 4 in elf2hex

### DIFF
--- a/fesvr/elf2hex.cc
+++ b/fesvr/elf2hex.cc
@@ -14,9 +14,9 @@ int main(int argc, char** argv)
   }
 
   unsigned width = atoi(argv[1]);
-  if(width < 8 || (width & (width-1)))
+  if(width < 4 || (width & (width-1)))
   {
-    std::cerr << "width must be at least 8 and a power of 2" << std::endl;
+    std::cerr << "width must be at least 4 and a power of 2" << std::endl;
     return 1;
   }
 


### PR DESCRIPTION
This commit relaxes the elf2hex width requirement to 4, enabling 32-bit wide boot ROMs.