### PR TITLE
Don't interrupt core on riscv-test exit only on syscall

### DIFF
--- a/fesvr/syscall.cc
+++ b/fesvr/syscall.cc
@@ -106,6 +106,7 @@ void syscall_t::handle_syscall(command_t cmd)
     htif->exitcode = cmd.payload();
     if (htif->exit_code())
       std::cerr << "*** FAILED *** (tohost = " << htif->exit_code() << ")" << std::endl;
+    return;
   }
   else // proxied system call
     dispatch(cmd.payload());


### PR DESCRIPTION
Currently the virtual tests in riscv-test end in a strange state because after exiting the test via a tohost write the fesvr responds with 1 which interrupts the processor sending it into a different tohost writing loop.
This seems like an oversight and simply returning before the response causes the tests to end in a more sane state (infinite loop after tohost write).