### PR TITLE
Add missing include stdlib.h

### DIFF
--- a/fesvr/htif_eth.cc
+++ b/fesvr/htif_eth.cc
@@ -5,6 +5,7 @@
 #include <sys/types.h>
 #include <termios.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
 #include <assert.h>
 #include <fcntl.h>


### PR DESCRIPTION
To compile with clang stdlib needs to be included. Clang complains that `abort()` isn't declared.

Cheers
David