### PR TITLE
fix compiling on osx/clang

### DIFF
--- a/fesvr/device.h
+++ b/fesvr/device.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <queue>
 #include <cstring>
+#include <string>
 #include <functional>
 
 class htif_t;

--- a/fesvr/elfloader.cc
+++ b/fesvr/elfloader.cc
@@ -2,7 +2,8 @@
 
 #include "elf.h"
 #include "memif.h"
-#include <string.h>
+#include <cstring>
+#include <string>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <sys/mman.h>


### PR DESCRIPTION
OS X's C++ libraries have shifted around where the string templates are, so including the newer <string> is able to fix compile errors.