### PR TITLE
fixing an issue causing spike to segfault with glibc<2.8

### DIFF
--- a/fesvr/context.h
+++ b/fesvr/context.h
@@ -10,6 +10,14 @@
 # define USE_UCONTEXT
 # include <ucontext.h>
 # include <memory>
+
+#if (100*GLIB_MAJOR_VERSION+GLIB_MINOR_VERSION < 208)
+#define GLIBC_64BIT_PTR_BUG
+static_assert (sizeof(unsigned int)  == 4, "uint size doesn't match expected 32bit");
+static_assert (sizeof(unsigned long) == 8, "ulong size doesn't match expected 64bit");
+static_assert (sizeof(void*)         == 8, "ptr size doesn't match expected 64bit");
+#endif
+
 #endif
 
 class context_t
@@ -26,7 +34,11 @@ class context_t
   void* arg;
 #ifdef USE_UCONTEXT
   std::unique_ptr<ucontext_t> context;
+#ifndef GLIBC_64BIT_PTR_BUG
   static void wrapper(context_t*);
+#else
+  static void wrapper(unsigned int, unsigned int);
+#endif
 #else
   pthread_t thread;
   pthread_mutex_t mutex;


### PR DESCRIPTION
Fixing an issue I reported at : https://groups.google.com/a/groups.riscv.org/forum/#!topic/sw-dev/YK7xA9sfVZc

There is a bug within contexts in the code using glibc ucontexts. A pointer is passed to makecontext. 

Documentation states (http://man7.org/linux/man-pages/man3/makecontext.3.html):
	On architectures where int and pointer types are the same size (e.g.,
       x86-32, where both types are 32 bits), you may be able to get away
       with passing pointers as arguments to makecontext() following argc.
       However, doing this is not guaranteed to be portable, is undefined
       according to the standards, and won't work on architectures where
       pointers are larger than ints.  Nevertheless, starting with version
       2.8, glibc makes some changes to makecontext(), to permit this on
       some 64-bit architectures (e.g., x86-64).

I happen to use glibc2.5 therefore was prone to this bug. Symptoms were segfaulting in context_t::wrapper due to ctx pointing to unaccessible memory.
In my case it was pointing to 0xffff_ffff_ffff_fd30. However, when I traced the creation of that context, it’s ptr was 0x7fff_ffff_fd30 (it is target in sim.cc that is on the stack).

My patch is splitting the pointer into hi/lo 32bit parts and should kick in for glibc<2.8. Confirmed that with this patch spike now works fine with my glibc 2.5 .
