### PR TITLE
add switch_to_target to tsi

### DIFF
--- a/fesvr/tsi.cc
+++ b/fesvr/tsi.cc
@@ -65,7 +65,7 @@ void tsi_t::read_chunk(addr_t taddr, size_t nbytes, void* dst)
 
   for (size_t i = 0; i < len; i++) {
     while (out_data.empty())
-      target->switch_to();
+      switch_to_target();
     result[i] = out_data.front();
     out_data.pop_front();
   }
@@ -103,6 +103,11 @@ bool tsi_t::data_available(void)
 void tsi_t::switch_to_host(void)
 {
   host.switch_to();
+}
+
+void tsi_t::switch_to_target(void)
+{
+  target->switch_to();
 }
 
 int tsi_t::get_ipi_addrs(addr_t *ipis)

--- a/fesvr/tsi.h
+++ b/fesvr/tsi.h
@@ -35,6 +35,7 @@ class tsi_t : public htif_t
   void reset() override;
   void read_chunk(addr_t taddr, size_t nbytes, void* dst) override;
   void write_chunk(addr_t taddr, size_t nbytes, const void* src) override;
+  void switch_to_target();
 
   size_t chunk_align() { return 4; }
   size_t chunk_max_size() { return 1024; }


### PR DESCRIPTION
This is useful when we override the `idle` method to decrease polling frequency.