### PR TITLE
add a base argument to elf2hex

### DIFF
--- a/fesvr/elf2hex.cc
+++ b/fesvr/elf2hex.cc
@@ -7,10 +7,20 @@
 
 int main(int argc, char** argv)
 {
-  if(argc != 4)
+  if(argc < 4 || argc > 5)
   {
-    std::cerr << "Usage: " << argv[0] << " <width> <depth> <elf_file>" << std::endl;
+    std::cerr << "Usage: " << argv[0] << " <width> <depth> <elf_file> [base]" << std::endl;
     return 1;
+  }
+
+  unsigned long long int base = 0;
+  if(argc==5) {
+    base = atoll(argv[4]);
+    if((base & (base-1)))
+    {
+      std::cerr << "base must be a power of 2" << std::endl;
+      return 1;
+    }
   }
 
   unsigned width = atoi(argv[1]);
@@ -27,7 +37,7 @@ int main(int argc, char** argv)
     return 1;
   }
 
-  htif_hexwriter_t htif(width, depth);
+  htif_hexwriter_t htif(base, width, depth);
   memif_t memif(&htif);
   load_elf(argv[3], &memif);
   std::cout << htif;

--- a/fesvr/htif_hexwriter.cc
+++ b/fesvr/htif_hexwriter.cc
@@ -4,13 +4,15 @@
 #include <assert.h>
 #include "htif_hexwriter.h"
 
-htif_hexwriter_t::htif_hexwriter_t(size_t w, size_t d)
-  : htif_t(std::vector<std::string>()), width(w), depth(d)
+htif_hexwriter_t::htif_hexwriter_t(size_t b, size_t w, size_t d)
+  : htif_t(std::vector<std::string>()), base(b), width(w), depth(d)
 {
 }
 
 void htif_hexwriter_t::read_chunk(addr_t taddr, size_t len, void* vdst)
 {
+  taddr -= base;
+
   assert(len % chunk_align() == 0);
   assert(taddr < width*depth);
   assert(taddr+len <= width*depth);
@@ -32,6 +34,8 @@ void htif_hexwriter_t::read_chunk(addr_t taddr, size_t len, void* vdst)
 
 void htif_hexwriter_t::write_chunk(addr_t taddr, size_t len, const void* vsrc)
 {
+  taddr -= base;
+
   assert(len % chunk_align() == 0);
   assert(taddr < width*depth);
   assert(taddr+len <= width*depth);

--- a/fesvr/htif_hexwriter.h
+++ b/fesvr/htif_hexwriter.h
@@ -11,9 +11,10 @@
 class htif_hexwriter_t : public htif_t
 {
 public:
-  htif_hexwriter_t(size_t w, size_t d);
+  htif_hexwriter_t(size_t b, size_t w, size_t d);
 
 protected:
+  size_t base;
   size_t width;
   size_t depth;
   std::map<addr_t,std::vector<char> > mem;


### PR DESCRIPTION
Allow hex files to be generated for ELF files with a base offset.
The base argument is optional, so should have the minimal impact on the previous use case.