### PR TITLE
Approach for exposing HTIF options to other tools

### DIFF
--- a/fesvr/dtm.cc
+++ b/fesvr/dtm.cc
@@ -584,8 +584,8 @@ void dtm_t::start_host_thread()
   host.switch_to();
 }
 
-dtm_t::dtm_t(const std::vector<std::string>& args)
-  : htif_t(args)
+dtm_t::dtm_t(int argc, char** argv)
+  : htif_t(argc, argv)
 {
   start_host_thread();
 }

--- a/fesvr/dtm.h
+++ b/fesvr/dtm.h
@@ -14,7 +14,7 @@
 class dtm_t : public htif_t
 {
  public:
-  dtm_t(const std::vector<std::string>& args);
+  dtm_t(int argc, char**argv);
   ~dtm_t();
 
   struct req {

--- a/fesvr/htif.cc
+++ b/fesvr/htif.cc
@@ -39,6 +39,21 @@ static void handle_signal(int sig)
   signal(sig, &handle_signal);
 }
 
+htif_t::htif_t()
+  : mem(this), entry(DRAM_BASE), sig_addr(0), sig_len(0),
+    tohost_addr(0), fromhost_addr(0), exitcode(0), stopped(false),
+    syscall_proxy(this)
+{
+  signal(SIGINT, &handle_signal);
+  signal(SIGTERM, &handle_signal);
+  signal(SIGABRT, &handle_signal); // we still want to call static destructors
+
+  device_list.register_device(&syscall_proxy);
+  device_list.register_device(&bcd);
+  for (auto d : dynamic_devices)
+    device_list.register_device(d);
+}
+
 htif_t::htif_t(int argc, char** argv)
   : mem(this), entry(DRAM_BASE), sig_addr(0), sig_len(0),
     tohost_addr(0), fromhost_addr(0), exitcode(0), stopped(false),

--- a/fesvr/htif.h
+++ b/fesvr/htif.h
@@ -14,6 +14,7 @@ class htif_t
  public:
   htif_t();
   htif_t(int argc, char** argv);
+  htif_t(const std::vector<std::string>& args);
   virtual ~htif_t();
 
   virtual void start();
@@ -43,6 +44,9 @@ class htif_t
   reg_t get_entry_point() { return entry; }
 
  private:
+  void parse_arguments(int argc, char ** argv);
+  void register_devices();
+
   memif_t mem;
   reg_t entry;
   bool writezeros;

--- a/fesvr/htif.h
+++ b/fesvr/htif.h
@@ -12,6 +12,7 @@
 class htif_t
 {
  public:
+  htif_t();
   htif_t(int argc, char** argv);
   virtual ~htif_t();
 
@@ -66,17 +67,21 @@ class htif_t
   friend class syscall_t;
 };
 
+/* Aligntment guide for emulator.cc options:
+  -x, --long-option        Description with max 80 characters --------------->\n\
+       +plus-arg-equivalent\n\
+ */
 #define HTIF_USAGE_OPTIONS "HOST OPTIONS\n\
-  --rfb=[DISPLAY]            Add new remote frame buffer on display DISPLAY\n\
-       +rfb=[DISPLAY]        to be accessible on 5900 + DISPLAY (default = 0)\n\
-  --signature=[FILE]         Write torture test signature to FILE\n\
-       +signature=[FILE]\n\
-  --chroot=[PATH]            Use PATH as location of syscall-servicing binaries\n\
-       +chroot=[PATH]\n\
+      --rfb=DISPLAY        Add new remote frame buffer on display DISPLAY\n\
+       +rfb=DISPLAY          to be accessible on 5900 + DISPLAY (default = 0)\n\
+      --signature=FILE     Write torture test signature to FILE\n\
+       +signature=FILE\n\
+      --chroot=PATH        Use PATH as location of syscall-servicing binaries\n\
+       +chroot=PATH\n\
 \n\
 HOST OPTIONS (currently unsupported)\n\
-  --disk=[DISK]              Add DISK device. Use a ramdisk since this isn't\n\
-       +disk=[DISK]          supported\n\
+      --disk=DISK          Add DISK device. Use a ramdisk since this isn't\n\
+       +disk=DISK            supported\n\
 \n\
 TARGET (RISC-V BINARY) OPTIONS\n\
   These are the options passed to the program executing on the emulated RISC-V\n\

--- a/fesvr/htif.h
+++ b/fesvr/htif.h
@@ -12,7 +12,7 @@
 class htif_t
 {
  public:
-  htif_t(const std::vector<std::string>& target_args);
+  htif_t(int argc, char** argv);
   virtual ~htif_t();
 
   virtual void start();
@@ -65,5 +65,29 @@ class htif_t
   friend class memif_t;
   friend class syscall_t;
 };
+
+#define HTIF_USAGE_OPTIONS "HOST OPTIONS\n\
+  --rfb=[DISPLAY]            Add new remote frame buffer on display DISPLAY\n\
+       +rfb=[DISPLAY]        to be accessible on 5900 + DISPLAY (default = 0)\n\
+  --signature=[FILE]         Write torture test signature to FILE\n\
+       +signature=[FILE]\n\
+  --chroot=[PATH]            Use PATH as location of syscall-servicing binaries\n\
+       +chroot=[PATH]\n\
+\n\
+HOST OPTIONS (currently unsupported)\n\
+  --disk=[DISK]              Add DISK device. Use a ramdisk since this isn't\n\
+       +disk=[DISK]          supported\n\
+\n\
+TARGET (RISC-V BINARY) OPTIONS\n\
+  These are the options passed to the program executing on the emulated RISC-V\n\
+  microprocessor.\n"
+
+#define HTIF_LONG_OPTIONS_OPTIND 1024
+#define HTIF_LONG_OPTIONS                                               \
+{"rfb",       optional_argument, 0, HTIF_LONG_OPTIONS_OPTIND     },     \
+{"disk",      required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 1 },     \
+{"signature", required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 2 },     \
+{"chroot",    required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 3 },     \
+{0, 0, 0, 0}
 
 #endif // __HTIF_H

--- a/fesvr/htif_hexwriter.cc
+++ b/fesvr/htif_hexwriter.cc
@@ -5,7 +5,7 @@
 #include "htif_hexwriter.h"
 
 htif_hexwriter_t::htif_hexwriter_t(size_t b, size_t w, size_t d)
-  : htif_t(0, nullptr), base(b), width(w), depth(d)
+  : htif_t(), base(b), width(w), depth(d)
 {
 }
 

--- a/fesvr/htif_hexwriter.cc
+++ b/fesvr/htif_hexwriter.cc
@@ -5,7 +5,7 @@
 #include "htif_hexwriter.h"
 
 htif_hexwriter_t::htif_hexwriter_t(size_t b, size_t w, size_t d)
-  : htif_t(std::vector<std::string>()), base(b), width(w), depth(d)
+  : htif_t(0, nullptr), base(b), width(w), depth(d)
 {
 }
 

--- a/fesvr/htif_pthread.cc
+++ b/fesvr/htif_pthread.cc
@@ -12,8 +12,8 @@ void htif_pthread_t::thread_main(void* arg)
     htif->target->switch_to();
 }
 
-htif_pthread_t::htif_pthread_t(const std::vector<std::string>& args)
-  : htif_t(args)
+htif_pthread_t::htif_pthread_t(int argc, char** argv)
+    : htif_t(argc, argv)
 {
   target = context_t::current();
   host.init(thread_main, this);
@@ -27,7 +27,7 @@ ssize_t htif_pthread_t::read(void* buf, size_t max_size)
 {
   while (th_data.size() == 0)
     target->switch_to();
-    
+
   size_t s = std::min(max_size, th_data.size());
   std::copy(th_data.begin(), th_data.begin() + s, (char*)buf);
   th_data.erase(th_data.begin(), th_data.begin() + s);

--- a/fesvr/htif_pthread.h
+++ b/fesvr/htif_pthread.h
@@ -10,7 +10,7 @@
 class htif_pthread_t : public htif_t
 {
  public:
-  htif_pthread_t(const std::vector<std::string>& target_args);
+  htif_pthread_t(int argc, char** argv);
   virtual ~htif_pthread_t();
 
   // target inteface

--- a/fesvr/syscall.cc
+++ b/fesvr/syscall.cc
@@ -386,7 +386,7 @@ void syscall_t::set_chroot(const char* where)
       || getcwd(buf2, sizeof(buf2)) == NULL
       || chdir(buf1) != 0)
   {
-    fprintf(stderr, "could not chroot to %s\n", chroot.c_str());
+    fprintf(stderr, "could not chroot to %s\n", where);
     exit(-1);
   }
 

--- a/fesvr/tsi.cc
+++ b/fesvr/tsi.cc
@@ -13,7 +13,7 @@ void tsi_t::host_thread(void *arg)
     tsi->target->switch_to();
 }
 
-tsi_t::tsi_t(const std::vector<std::string>& args) : htif_t(args)
+tsi_t::tsi_t(int argc, char** argv) : htif_t(argc, argv)
 {
   target = context_t::current();
   host.init(host_thread, this);

--- a/fesvr/tsi.h
+++ b/fesvr/tsi.h
@@ -18,7 +18,7 @@
 class tsi_t : public htif_t
 {
  public:
-  tsi_t(const std::vector<std::string>& target_args);
+  tsi_t(int argc, char** argv);
   virtual ~tsi_t();
 
   bool data_available();


### PR DESCRIPTION
This provides one strategy for exposing what options are supported by the host to other tools. This uses `getopt_long` for all argument parsing and exposes the data structures necessary for the parsing in `htif_t.h`.

As it's necessary to still provide backwards support for `spike` and `elf2hex`, two additional legacy constructors are provided for `htif_t`:
  - A no-argument constructor (for `elf2hex`)
  - A constructor taking `std::vector<std::string>` (for `spike`)

Summarily:
* Add `htif_t` constructor that uses `(int argc, char** argv)` instead of `(const std::vector<std::string>)`
* Use `getopt_long` for option parsing and add equivalent `--` long options to all existing `+` options
* Expose supported `htif_t` options to external programs via macros in `htif_t.h` (see freechipsproject/rocket-chip#597)
* Trying to use the `+disk` option will throw a `std::invalid_argument` exception (as I'm still not aware of this being supported)
* Add check on options that should be skipped -- currently limited to VCS' `-cm XXX+YYY`
* Fix incorrect `set_chroot` error message

Fixes #24. 

Due to the use of the legacy `std::vector<std::string>` this should, theoretically, not break anything. However, it may... I was unaware until trying to build `riscv-torture` that `elf2hex` wants to pass empty options into the `htif_t` constructor.

This is intended to be backed up by freechipsproject/rocket-chip#597.