### PR TITLE
debug_v13: Support Debug v13

### DIFF
--- a/fesvr/debug_defines.h
+++ b/fesvr/debug_defines.h
@@ -1,0 +1,1506 @@
+#define DTM_IDCODE                          0x01
+/*
+* Identifies the release version of this part.
+ */
+#define DTM_IDCODE_VERSION_OFFSET           28
+#define DTM_IDCODE_VERSION_LENGTH           4
+#define DTM_IDCODE_VERSION                  (0xf << DTM_IDCODE_VERSION_OFFSET)
+/*
+* Identifies the designer's part number of this part.
+ */
+#define DTM_IDCODE_PARTNUMBER_OFFSET        12
+#define DTM_IDCODE_PARTNUMBER_LENGTH        16
+#define DTM_IDCODE_PARTNUMBER               (0xffff << DTM_IDCODE_PARTNUMBER_OFFSET)
+/*
+* Identifies the designer/manufacturer of this part. Bits 6:0 must be
+* bits 6:0 of the designer/manufacturer's Identification Code as
+* assigned by JEDEC Standard JEP106. Bits 10:7 contain the modulo-16
+* count of the number of continuation characters (0x7f) in that same
+* Identification Code.
+ */
+#define DTM_IDCODE_MANUFID_OFFSET           1
+#define DTM_IDCODE_MANUFID_LENGTH           11
+#define DTM_IDCODE_MANUFID                  (0x7ff << DTM_IDCODE_MANUFID_OFFSET)
+#define DTM_IDCODE_1_OFFSET                 0
+#define DTM_IDCODE_1_LENGTH                 1
+#define DTM_IDCODE_1                        (0x1 << DTM_IDCODE_1_OFFSET)
+#define DTM_DTMCS                           0x10
+/*
+* Writing 1 to this bit resets the DMI controller, clearing any
+* sticky error state.
+ */
+#define DTM_DTMCS_DMIRESET_OFFSET           16
+#define DTM_DTMCS_DMIRESET_LENGTH           1
+#define DTM_DTMCS_DMIRESET                  (0x1 << DTM_DTMCS_DMIRESET_OFFSET)
+/*
+* This is the minimum number of cycles a debugger should spend in
+* Run-Test/Idle after every DMI scan to avoid a 'busy'
+* return code (\Fdmistat of 3). A debugger must still
+* check \Fdmistat when necessary.
+*
+* 0: It is not necessary to enter Run-Test/Idle at all.
+*
+* 1: Enter Run-Test/Idle and leave it immediately.
+*
+* 2: Enter Run-Test/Idle and stay there for 1 cycle before leaving.
+*
+* And so on.
+ */
+#define DTM_DTMCS_IDLE_OFFSET               12
+#define DTM_DTMCS_IDLE_LENGTH               3
+#define DTM_DTMCS_IDLE                      (0x7 << DTM_DTMCS_IDLE_OFFSET)
+/*
+* 0: No error.
+*
+* 1: Reserved. Interpret the same as 2.
+*
+* 2: An operation failed (resulted in \Fop of 2).
+*
+* 3: An operation was attempted while a DMI access was still in
+* progress (resulted in \Fop of 3).
+ */
+#define DTM_DTMCS_DMISTAT_OFFSET            10
+#define DTM_DTMCS_DMISTAT_LENGTH            2
+#define DTM_DTMCS_DMISTAT                   (0x3 << DTM_DTMCS_DMISTAT_OFFSET)
+/*
+* The size of \Faddress in \Rdmi.
+ */
+#define DTM_DTMCS_ABITS_OFFSET              4
+#define DTM_DTMCS_ABITS_LENGTH              6
+#define DTM_DTMCS_ABITS                     (0x3f << DTM_DTMCS_ABITS_OFFSET)
+/*
+* 0: Version described in spec version 0.11.
+*
+* 1: Version described in spec version 0.12 (and later?), which
+* reduces the DMI data width to 32 bits.
+*
+* Other values are reserved for future use.
+ */
+#define DTM_DTMCS_VERSION_OFFSET            0
+#define DTM_DTMCS_VERSION_LENGTH            4
+#define DTM_DTMCS_VERSION                   (0xf << DTM_DTMCS_VERSION_OFFSET)
+#define DTM_DMI                             0x11
+/*
+* Address used for DMI access. In Update-DR this value is used
+* to access the DM over the DMI.
+ */
+#define DTM_DMI_ADDRESS_OFFSET              34
+#define DTM_DMI_ADDRESS_LENGTH              abits
+#define DTM_DMI_ADDRESS                     (((1L<<abits)-1) << DTM_DMI_ADDRESS_OFFSET)
+/*
+* The data to send to the DM over the DMI during Update-DR, and
+* the data returned from the DM as a result of the previous operation.
+ */
+#define DTM_DMI_DATA_OFFSET                 2
+#define DTM_DMI_DATA_LENGTH                 32
+#define DTM_DMI_DATA                        (0xffffffffL << DTM_DMI_DATA_OFFSET)
+/*
+* When the debugger writes this field, it has the following meaning:
+*
+* 0: Ignore \Fdata. (nop)
+*
+* 1: Read from \Faddress. (read)
+*
+* 2: Write \Fdata to \Faddress. (write)
+*
+* 3: Reserved.
+*
+* When the debugger reads this field, it means the following:
+*
+* 0: The previous operation completed successfully.
+*
+* 1: Reserved.
+*
+* 2: A previous operation failed.  The data scanned into \Rdmi in
+* this access will be ignored.  This status is sticky and can be
+* cleared by writing \Fdmireset in \Rdtmcs.
+*
+* This indicates that the DM itself responded with an error, e.g.
+* in the System Bus and Serial Port overflow/underflow cases.
+*
+* 3: An operation was attempted while a DMI request is still in
+* progress. The data scanned into \Rdmi in this access will be
+* ignored. This status is sticky and can be cleared by writing
+* \Fdmireset in \Rdtmcs. If a debugger sees this status, it
+* needs to give the target more TCK edges between Update-DR and
+* Capture-DR. The simplest way to do that is to add extra transitions
+* in Run-Test/Idle.
+*
+* (The DTM, DM, and/or component may be in different clock domains,
+* so synchronization may be required. Some relatively fixed number of
+* TCK ticks may be needed for the request to reach the DM, complete,
+* and for the response to be synchronized back into the TCK domain.)
+ */
+#define DTM_DMI_OP_OFFSET                   0
+#define DTM_DMI_OP_LENGTH                   2
+#define DTM_DMI_OP                          (0x3L << DTM_DMI_OP_OFFSET)
+#define CSR_DCSR                            0x7b0
+/*
+* 0: There is no external debug support.
+*
+* 1: External debug support exists as it is described in this document.
+*
+* Other values are reserved for future standards.
+ */
+#define CSR_DCSR_XDEBUGVER_OFFSET           30
+#define CSR_DCSR_XDEBUGVER_LENGTH           2
+#define CSR_DCSR_XDEBUGVER                  (0x3 << CSR_DCSR_XDEBUGVER_OFFSET)
+/*
+* When 1, {\tt ebreak} instructions in Machine Mode enter Debug Mode.
+ */
+#define CSR_DCSR_EBREAKM_OFFSET             15
+#define CSR_DCSR_EBREAKM_LENGTH             1
+#define CSR_DCSR_EBREAKM                    (0x1 << CSR_DCSR_EBREAKM_OFFSET)
+/*
+* When 1, {\tt ebreak} instructions in Hypervisor Mode enter Debug Mode.
+ */
+#define CSR_DCSR_EBREAKH_OFFSET             14
+#define CSR_DCSR_EBREAKH_LENGTH             1
+#define CSR_DCSR_EBREAKH                    (0x1 << CSR_DCSR_EBREAKH_OFFSET)
+/*
+* When 1, {\tt ebreak} instructions in Supervisor Mode enter Debug Mode.
+ */
+#define CSR_DCSR_EBREAKS_OFFSET             13
+#define CSR_DCSR_EBREAKS_LENGTH             1
+#define CSR_DCSR_EBREAKS                    (0x1 << CSR_DCSR_EBREAKS_OFFSET)
+/*
+* When 1, {\tt ebreak} instructions in User/Application Mode enter
+* Debug Mode.
+ */
+#define CSR_DCSR_EBREAKU_OFFSET             12
+#define CSR_DCSR_EBREAKU_LENGTH             1
+#define CSR_DCSR_EBREAKU                    (0x1 << CSR_DCSR_EBREAKU_OFFSET)
+/*
+* 0: Increment counters as usual.
+*
+* 1: Don't increment any counters while in Debug Mode.  This includes
+* the {\tt cycle} and {\tt instret} CSRs. This is preferred for most
+* debugging scenarios.
+*
+* An implementation may choose not to support writing to this bit.
+* The debugger must read back the value it writes to check whether
+* the feature is supported.
+ */
+#define CSR_DCSR_STOPCOUNT_OFFSET           10
+#define CSR_DCSR_STOPCOUNT_LENGTH           1
+#define CSR_DCSR_STOPCOUNT                  (0x1 << CSR_DCSR_STOPCOUNT_OFFSET)
+/*
+* 0: Increment timers as usual.
+*
+* 1: Don't increment any hart-local timers while in Debug Mode.
+*
+* An implementation may choose not to support writing to this bit.
+* The debugger must read back the value it writes to check whether
+* the feature is supported.
+ */
+#define CSR_DCSR_STOPTIME_OFFSET            9
+#define CSR_DCSR_STOPTIME_LENGTH            1
+#define CSR_DCSR_STOPTIME                   (0x1 << CSR_DCSR_STOPTIME_OFFSET)
+/*
+* Explains why Debug Mode was entered.
+*
+* When there are multiple reasons to enter Debug Mode in a single
+* cycle, the cause with the highest priority is the one written.
+*
+* 1: A software breakpoint was hit. (priority 3)
+*
+* 2: The Trigger Module caused a halt. (priority 4)
+*
+* 3: The debug interrupt was asserted by the Debug Module. (priority 2)
+*
+* 4: The hart single stepped because \Fstep was set. (priority 1)
+*
+* 5: \Fhaltreq was set. (priority 0)
+*
+* Other values are reserved for future use.
+ */
+#define CSR_DCSR_CAUSE_OFFSET               6
+#define CSR_DCSR_CAUSE_LENGTH               3
+#define CSR_DCSR_CAUSE                      (0x7 << CSR_DCSR_CAUSE_OFFSET)
+/*
+* When set and not in Debug Mode, the hart will only execute a single
+* instruction, and then enter Debug Mode. Interrupts are disabled
+* when this bit is set.
+ */
+#define CSR_DCSR_STEP_OFFSET                2
+#define CSR_DCSR_STEP_LENGTH                1
+#define CSR_DCSR_STEP                       (0x1 << CSR_DCSR_STEP_OFFSET)
+/*
+* Contains the privilege level the hart was operating in when Debug
+* Mode was entered. The encoding is describe in Table
+* \ref{tab:privlevel}.  A debugger can change this value to change
+* the hart's privilege level when exiting Debug Mode.
+*
+* Not all privilege levels are supported on all harts. If the
+* encoding written is not supported or the debugger is not allowed to
+* change to it, the hart may change to any supported privilege level.
+ */
+#define CSR_DCSR_PRV_OFFSET                 0
+#define CSR_DCSR_PRV_LENGTH                 2
+#define CSR_DCSR_PRV                        (0x3 << CSR_DCSR_PRV_OFFSET)
+#define CSR_DPC                             0x7b1
+#define CSR_DPC_DPC_OFFSET                  0
+#define CSR_DPC_DPC_LENGTH                  XLEN
+#define CSR_DPC_DPC                         (((1L<<XLEN)-1) << CSR_DPC_DPC_OFFSET)
+#define CSR_DSCRATCH0                       0x7b2
+#define CSR_DSCRATCH1                       0x7b3
+#define CSR_PRIV                            virtual
+/*
+* Contains the privilege level the hart was operating in when Debug
+* Mode was entered. The encoding is describe in Table
+* \ref{tab:privlevel}. A user can write this value to change the
+* hart's privilege level when exiting Debug Mode.
+ */
+#define CSR_PRIV_PRV_OFFSET                 0
+#define CSR_PRIV_PRV_LENGTH                 2
+#define CSR_PRIV_PRV                        (0x3 << CSR_PRIV_PRV_OFFSET)
+#define CSR_TSELECT                         0x7a0
+#define CSR_TSELECT_INDEX_OFFSET            0
+#define CSR_TSELECT_INDEX_LENGTH            XLEN
+#define CSR_TSELECT_INDEX                   (((1L<<XLEN)-1) << CSR_TSELECT_INDEX_OFFSET)
+#define CSR_TDATA1                          0x7a1
+/*
+* 0: There is no trigger at this \Rtselect.
+*
+* 1: The trigger is a legacy SiFive address match trigger. These
+* should not be implemented and aren't further documented here.
+*
+* 2: The trigger is an address/data match trigger. The remaining bits
+* in this register act as described in \Rmcontrol.
+*
+* 3: The trigger is an instruction count trigger. The remaining bits
+* in this register act as described in \Ricount.
+*
+* 15: This trigger exists (so enumeration shouldn't terminate), but
+* is not currently available.
+*
+* Other values are reserved for future use.
+ */
+#define CSR_TDATA1_TYPE_OFFSET              XLEN-4
+#define CSR_TDATA1_TYPE_LENGTH              4
+#define CSR_TDATA1_TYPE                     (0xfL << CSR_TDATA1_TYPE_OFFSET)
+/*
+* 0: Both Debug and M Mode can write the {\tt tdata} registers at the
+* selected \Rtselect.
+*
+* 1: Only Debug Mode can write the {\tt tdata} registers at the
+* selected \Rtselect.  Writes from other modes are ignored.
+*
+* This bit is only writable from Debug Mode.
+ */
+#define CSR_TDATA1_HMODE_OFFSET             XLEN-5
+#define CSR_TDATA1_HMODE_LENGTH             1
+#define CSR_TDATA1_HMODE                    (0x1L << CSR_TDATA1_HMODE_OFFSET)
+/*
+* Trigger-specific data.
+ */
+#define CSR_TDATA1_DATA_OFFSET              0
+#define CSR_TDATA1_DATA_LENGTH              XLEN - 5
+#define CSR_TDATA1_DATA                     (((1L<<XLEN - 5)-1) << CSR_TDATA1_DATA_OFFSET)
+#define CSR_TDATA2                          0x7a2
+#define CSR_TDATA2_DATA_OFFSET              0
+#define CSR_TDATA2_DATA_LENGTH              XLEN
+#define CSR_TDATA2_DATA                     (((1L<<XLEN)-1) << CSR_TDATA2_DATA_OFFSET)
+#define CSR_TDATA3                          0x7a3
+#define CSR_TDATA3_DATA_OFFSET              0
+#define CSR_TDATA3_DATA_LENGTH              XLEN
+#define CSR_TDATA3_DATA                     (((1L<<XLEN)-1) << CSR_TDATA3_DATA_OFFSET)
+#define CSR_MCONTROL                        0x7a1
+#define CSR_MCONTROL_TYPE_OFFSET            XLEN-4
+#define CSR_MCONTROL_TYPE_LENGTH            4
+#define CSR_MCONTROL_TYPE                   (0xfL << CSR_MCONTROL_TYPE_OFFSET)
+#define CSR_MCONTROL_DMODE_OFFSET           XLEN-5
+#define CSR_MCONTROL_DMODE_LENGTH           1
+#define CSR_MCONTROL_DMODE                  (0x1L << CSR_MCONTROL_DMODE_OFFSET)
+/*
+* Specifies the largest naturally aligned powers-of-two (NAPOT) range
+* supported by the hardware. The value is the logarithm base 2 of the
+* number of bytes in that range.  A value of 0 indicates that only
+* exact value matches are supported (one byte range). A value of 63
+* corresponds to the maximum NAPOT range, which is $2^{63}$ bytes in
+* size.
+ */
+#define CSR_MCONTROL_MASKMAX_OFFSET         XLEN-11
+#define CSR_MCONTROL_MASKMAX_LENGTH         6
+#define CSR_MCONTROL_MASKMAX                (0x3fL << CSR_MCONTROL_MASKMAX_OFFSET)
+/*
+* 0: Perform a match on the virtual address.
+*
+* 1: Perform a match on the data value loaded/stored, or the
+* instruction executed.
+ */
+#define CSR_MCONTROL_SELECT_OFFSET          19
+#define CSR_MCONTROL_SELECT_LENGTH          1
+#define CSR_MCONTROL_SELECT                 (0x1L << CSR_MCONTROL_SELECT_OFFSET)
+/*
+* 0: The action for this trigger will be taken just before the
+* instruction that triggered it is executed, but after all preceding
+* instructions are are committed.
+*
+* 1: The action for this trigger will be taken after the instruction
+* that triggered it is executed. It should be taken before the next
+* instruction is executed, but it is better to implement triggers and
+* not implement that suggestion than to not implement them at all.
+*
+* Most hardware will only implement one timing or the other, possibly
+* dependent on \Fselect, \Fexecute, \Fload, and \Fstore. This bit
+* primarily exists for the hardware to communicate to the debugger
+* what will happen. Hardware may implement the bit fully writable, in
+* which case the debugger has a little more control.
+*
+* Data load triggers with \Ftiming of 0 will result in the same load
+* happening again when the debugger lets the core run. For data load
+* triggers, debuggers must first attempt to set the breakpoint with
+* \Ftiming of 1.
+*
+* A chain of triggers that don't all have the same \Ftiming value
+* will never fire (unless consecutive instructions match the
+* appropriate triggers).
+ */
+#define CSR_MCONTROL_TIMING_OFFSET          18
+#define CSR_MCONTROL_TIMING_LENGTH          1
+#define CSR_MCONTROL_TIMING                 (0x1L << CSR_MCONTROL_TIMING_OFFSET)
+/*
+* Determines what happens when this trigger matches.
+*
+* 0: Raise a breakpoint exception. (Used when software wants to use
+* the trigger module without an external debugger attached.)
+*
+* 1: Enter Debug Mode. (Only supported when \Fhmode is 1.)
+*
+* 2: Start tracing.
+*
+* 3: Stop tracing.
+*
+* 4: Emit trace data for this match. If it is a data access match,
+* emit appropriate Load/Store Address/Data. If it is an instruction
+* execution, emit its PC.
+*
+* Other values are reserved for future use.
+ */
+#define CSR_MCONTROL_ACTION_OFFSET          12
+#define CSR_MCONTROL_ACTION_LENGTH          6
+#define CSR_MCONTROL_ACTION                 (0x3fL << CSR_MCONTROL_ACTION_OFFSET)
+/*
+* 0: When this trigger matches, the configured action is taken.
+*
+* 1: While this trigger does not match, it prevents the trigger with
+* the next index from matching.
+ */
+#define CSR_MCONTROL_CHAIN_OFFSET           11
+#define CSR_MCONTROL_CHAIN_LENGTH           1
+#define CSR_MCONTROL_CHAIN                  (0x1L << CSR_MCONTROL_CHAIN_OFFSET)
+/*
+* 0: Matches when the value equals \Rtdatatwo.
+*
+* 1: Matches when the top M bits of the value match the top M bits of
+* \Rtdatatwo. M is XLEN-1 minus the index of the least-significant
+* bit containing 0 in \Rtdatatwo.
+*
+* 2: Matches when the value is greater than or equal to \Rtdatatwo.
+*
+* 3: Matches when the value is less than \Rtdatatwo.
+*
+* 4: Matches when the lower half of the value equals the lower half
+* of \Rtdatatwo after the lower half of the value is ANDed with the
+* upper half of \Rtdatatwo.
+*
+* 5: Matches when the upper half of the value equals the lower half
+* of \Rtdatatwo after the upper half of the value is ANDed with the
+* upper half of \Rtdatatwo.
+*
+* Other values are reserved for future use.
+ */
+#define CSR_MCONTROL_MATCH_OFFSET           7
+#define CSR_MCONTROL_MATCH_LENGTH           4
+#define CSR_MCONTROL_MATCH                  (0xfL << CSR_MCONTROL_MATCH_OFFSET)
+/*
+* When set, enable this trigger in M mode.
+ */
+#define CSR_MCONTROL_M_OFFSET               6
+#define CSR_MCONTROL_M_LENGTH               1
+#define CSR_MCONTROL_M                      (0x1L << CSR_MCONTROL_M_OFFSET)
+/*
+* When set, enable this trigger in H mode.
+ */
+#define CSR_MCONTROL_H_OFFSET               5
+#define CSR_MCONTROL_H_LENGTH               1
+#define CSR_MCONTROL_H                      (0x1L << CSR_MCONTROL_H_OFFSET)
+/*
+* When set, enable this trigger in S mode.
+ */
+#define CSR_MCONTROL_S_OFFSET               4
+#define CSR_MCONTROL_S_LENGTH               1
+#define CSR_MCONTROL_S                      (0x1L << CSR_MCONTROL_S_OFFSET)
+/*
+* When set, enable this trigger in U mode.
+ */
+#define CSR_MCONTROL_U_OFFSET               3
+#define CSR_MCONTROL_U_LENGTH               1
+#define CSR_MCONTROL_U                      (0x1L << CSR_MCONTROL_U_OFFSET)
+/*
+* When set, the trigger fires on the virtual address or opcode of an
+* instruction that is executed.
+ */
+#define CSR_MCONTROL_EXECUTE_OFFSET         2
+#define CSR_MCONTROL_EXECUTE_LENGTH         1
+#define CSR_MCONTROL_EXECUTE                (0x1L << CSR_MCONTROL_EXECUTE_OFFSET)
+/*
+* When set, the trigger fires on the virtual address or data of a store.
+ */
+#define CSR_MCONTROL_STORE_OFFSET           1
+#define CSR_MCONTROL_STORE_LENGTH           1
+#define CSR_MCONTROL_STORE                  (0x1L << CSR_MCONTROL_STORE_OFFSET)
+/*
+* When set, the trigger fires on the virtual address or data of a load.
+ */
+#define CSR_MCONTROL_LOAD_OFFSET            0
+#define CSR_MCONTROL_LOAD_LENGTH            1
+#define CSR_MCONTROL_LOAD                   (0x1L << CSR_MCONTROL_LOAD_OFFSET)
+#define CSR_ICOUNT                          0x7a1
+#define CSR_ICOUNT_TYPE_OFFSET              XLEN-4
+#define CSR_ICOUNT_TYPE_LENGTH              4
+#define CSR_ICOUNT_TYPE                     (0xfL << CSR_ICOUNT_TYPE_OFFSET)
+#define CSR_ICOUNT_DMODE_OFFSET             XLEN-5
+#define CSR_ICOUNT_DMODE_LENGTH             1
+#define CSR_ICOUNT_DMODE                    (0x1L << CSR_ICOUNT_DMODE_OFFSET)
+/*
+* When count is decremented to 0, the trigger fires. Instead of
+* changing \Fcount from 1 to 0, it is also acceptable for hardware to
+* clear \Fm, \Fh, \Fs, and \Fu. This allows \Fcount to be hard-wired
+* to 1 if this register just exists for single step.
+ */
+#define CSR_ICOUNT_COUNT_OFFSET             10
+#define CSR_ICOUNT_COUNT_LENGTH             14
+#define CSR_ICOUNT_COUNT                    (0x3fffL << CSR_ICOUNT_COUNT_OFFSET)
+/*
+* When set, every instruction completed in M mode decrements \Fcount
+* by 1.
+ */
+#define CSR_ICOUNT_M_OFFSET                 9
+#define CSR_ICOUNT_M_LENGTH                 1
+#define CSR_ICOUNT_M                        (0x1L << CSR_ICOUNT_M_OFFSET)
+/*
+* When set, every instruction completed in H mode decrements \Fcount
+* by 1.
+ */
+#define CSR_ICOUNT_H_OFFSET                 8
+#define CSR_ICOUNT_H_LENGTH                 1
+#define CSR_ICOUNT_H                        (0x1L << CSR_ICOUNT_H_OFFSET)
+/*
+* When set, every instruction completed in S mode decrements \Fcount
+* by 1.
+ */
+#define CSR_ICOUNT_S_OFFSET                 7
+#define CSR_ICOUNT_S_LENGTH                 1
+#define CSR_ICOUNT_S                        (0x1L << CSR_ICOUNT_S_OFFSET)
+/*
+* When set, every instruction completed in U mode decrements \Fcount
+* by 1.
+ */
+#define CSR_ICOUNT_U_OFFSET                 6
+#define CSR_ICOUNT_U_LENGTH                 1
+#define CSR_ICOUNT_U                        (0x1L << CSR_ICOUNT_U_OFFSET)
+/*
+* Determines what happens when this trigger matches.
+*
+* 0: Raise a debug exception. (Used when software wants to use the
+* trigger module without an external debugger attached.)
+*
+* 1: Enter Debug Mode. (Only supported when \Fhmode is 1.)
+*
+* 2: Start tracing.
+*
+* 3: Stop tracing.
+*
+* 4: Emit trace data for this match. If it is a data access match,
+* emit appropriate Load/Store Address/Data. If it is an instruction
+* execution, emit its PC.
+*
+* Other values are reserved for future use.
+ */
+#define CSR_ICOUNT_ACTION_OFFSET            0
+#define CSR_ICOUNT_ACTION_LENGTH            6
+#define CSR_ICOUNT_ACTION                   (0x3fL << CSR_ICOUNT_ACTION_OFFSET)
+#define DMI_DMSTATUS                        0x11
+/*
+* This field is 1 when all currently selected harts do not exist in this system.
+ */
+#define DMI_DMSTATUS_ALLNONEXISTENT_OFFSET  15
+#define DMI_DMSTATUS_ALLNONEXISTENT_LENGTH  1
+#define DMI_DMSTATUS_ALLNONEXISTENT         (0x1 << DMI_DMSTATUS_ALLNONEXISTENT_OFFSET)
+/*
+* This field is 1 when any currently selected hart does not exist in this system.
+ */
+#define DMI_DMSTATUS_ANYNONEXISTENT_OFFSET  14
+#define DMI_DMSTATUS_ANYNONEXISTENT_LENGTH  1
+#define DMI_DMSTATUS_ANYNONEXISTENT         (0x1 << DMI_DMSTATUS_ANYNONEXISTENT_OFFSET)
+/*
+* This field is 1 when all currently selected harts are unavailable.
+ */
+#define DMI_DMSTATUS_ALLUNAVAIL_OFFSET      13
+#define DMI_DMSTATUS_ALLUNAVAIL_LENGTH      1
+#define DMI_DMSTATUS_ALLUNAVAIL             (0x1 << DMI_DMSTATUS_ALLUNAVAIL_OFFSET)
+/*
+* This field is 1 when any currently selected hart is unavailable.
+ */
+#define DMI_DMSTATUS_ANYUNAVAIL_OFFSET      12
+#define DMI_DMSTATUS_ANYUNAVAIL_LENGTH      1
+#define DMI_DMSTATUS_ANYUNAVAIL             (0x1 << DMI_DMSTATUS_ANYUNAVAIL_OFFSET)
+/*
+* This field is 1 when all currently selected harts are running.
+ */
+#define DMI_DMSTATUS_ALLRUNNING_OFFSET      11
+#define DMI_DMSTATUS_ALLRUNNING_LENGTH      1
+#define DMI_DMSTATUS_ALLRUNNING             (0x1 << DMI_DMSTATUS_ALLRUNNING_OFFSET)
+/*
+* This field is 1 when any currently selected hart is running.
+ */
+#define DMI_DMSTATUS_ANYRUNNING_OFFSET      10
+#define DMI_DMSTATUS_ANYRUNNING_LENGTH      1
+#define DMI_DMSTATUS_ANYRUNNING             (0x1 << DMI_DMSTATUS_ANYRUNNING_OFFSET)
+/*
+* This field is 1 when all currently selected harts are halted.
+ */
+#define DMI_DMSTATUS_ALLHALTED_OFFSET       9
+#define DMI_DMSTATUS_ALLHALTED_LENGTH       1
+#define DMI_DMSTATUS_ALLHALTED              (0x1 << DMI_DMSTATUS_ALLHALTED_OFFSET)
+/*
+* This field is 1 when any currently selected hart is halted.
+ */
+#define DMI_DMSTATUS_ANYHALTED_OFFSET       8
+#define DMI_DMSTATUS_ANYHALTED_LENGTH       1
+#define DMI_DMSTATUS_ANYHALTED              (0x1 << DMI_DMSTATUS_ANYHALTED_OFFSET)
+/*
+* 0 when authentication is required before using the DM.  1 when the
+* authentication check has passed. On components that don't implement
+* authentication, this bit must be preset as 1.
+ */
+#define DMI_DMSTATUS_AUTHENTICATED_OFFSET   7
+#define DMI_DMSTATUS_AUTHENTICATED_LENGTH   1
+#define DMI_DMSTATUS_AUTHENTICATED          (0x1 << DMI_DMSTATUS_AUTHENTICATED_OFFSET)
+/*
+* 0: The authentication module is ready to process the next
+* read/write to \Rauthdata.
+*
+* 1: The authentication module is busy. Accessing \Rauthdata results
+* in unspecified behavior.
+*
+* \Fauthbusy only becomes set in immediate response to an access to
+* \Rauthdata.
+ */
+#define DMI_DMSTATUS_AUTHBUSY_OFFSET        6
+#define DMI_DMSTATUS_AUTHBUSY_LENGTH        1
+#define DMI_DMSTATUS_AUTHBUSY               (0x1 << DMI_DMSTATUS_AUTHBUSY_OFFSET)
+#define DMI_DMSTATUS_CFGSTRVALID_OFFSET     4
+#define DMI_DMSTATUS_CFGSTRVALID_LENGTH     1
+#define DMI_DMSTATUS_CFGSTRVALID            (0x1 << DMI_DMSTATUS_CFGSTRVALID_OFFSET)
+/*
+* Reserved for future use. Reads as 0.
+ */
+#define DMI_DMSTATUS_VERSIONHI_OFFSET       2
+#define DMI_DMSTATUS_VERSIONHI_LENGTH       2
+#define DMI_DMSTATUS_VERSIONHI              (0x3 << DMI_DMSTATUS_VERSIONHI_OFFSET)
+/*
+* 00: There is no Debug Module present.
+*
+* 01: There is a Debug Module and it conforms to version 0.11 of this
+* specification.
+*
+* 10: There is a Debug Module and it conforms to version 0.13 of this
+* specification.
+*
+* 11: Reserved for future use.
+ */
+#define DMI_DMSTATUS_VERSIONLO_OFFSET       0
+#define DMI_DMSTATUS_VERSIONLO_LENGTH       2
+#define DMI_DMSTATUS_VERSIONLO              (0x3 << DMI_DMSTATUS_VERSIONLO_OFFSET)
+#define DMI_DMCONTROL                       0x10
+/*
+* Halt request signal for all currently selected harts. When 1, the
+* hart will halt if it is not currently halted.
+* Setting both \Fhaltreq and \Fresumereq leads to undefined behavior.
+*
+* Writes apply to the new value of \Fhartsel and \Fhasel.
+ */
+#define DMI_DMCONTROL_HALTREQ_OFFSET        31
+#define DMI_DMCONTROL_HALTREQ_LENGTH        1
+#define DMI_DMCONTROL_HALTREQ               (0x1 << DMI_DMCONTROL_HALTREQ_OFFSET)
+/*
+* Resume request signal for all currently selected harts. When 1,
+* the hart will resume if it is currently halted.
+* Setting both \Fhaltreq and \Fresumereq leads to undefined behavior.
+*
+* Writes apply to the new value of \Fhartsel and \Fhasel.
+ */
+#define DMI_DMCONTROL_RESUMEREQ_OFFSET      30
+#define DMI_DMCONTROL_RESUMEREQ_LENGTH      1
+#define DMI_DMCONTROL_RESUMEREQ             (0x1 << DMI_DMCONTROL_RESUMEREQ_OFFSET)
+/*
+* This optional bit controls reset to all the currently selected harts.
+* To perform a reset the debugger writes 1, and then writes 0 to
+* deassert the reset signal.
+*
+* If this feature is not implemented, the bit always stays 0, so
+* after writing 1 the debugger can read the register back to see if
+* the feature is supported.
+*
+* Writes apply to the new value of \Fhartsel and \Fhasel.
+ */
+#define DMI_DMCONTROL_HARTRESET_OFFSET      29
+#define DMI_DMCONTROL_HARTRESET_LENGTH      1
+#define DMI_DMCONTROL_HARTRESET             (0x1 << DMI_DMCONTROL_HARTRESET_OFFSET)
+/*
+* Selects the  definition of currently selected harts.
+*
+* 0: There is a single currently selected hart, that selected by \Fhartsel.
+*
+* 1: There may be multiple currently selected harts -- that selected by \Fhartsel,
+* plus those selected by the hart array mask register.
+*
+* An implementation which does not implement the hart array mask register
+* should tie this field to 0. A debugger which wishes to use the hart array
+* mask register feature should set this bit and read back to see if the functionality
+* is supported.
+ */
+#define DMI_DMCONTROL_HASEL_OFFSET          26
+#define DMI_DMCONTROL_HASEL_LENGTH          1
+#define DMI_DMCONTROL_HASEL                 (0x1 << DMI_DMCONTROL_HASEL_OFFSET)
+/*
+* The DM-specific index of the hart to select. This hart is always part of the
+* currently selected harts.
+ */
+#define DMI_DMCONTROL_HARTSEL_OFFSET        16
+#define DMI_DMCONTROL_HARTSEL_LENGTH        10
+#define DMI_DMCONTROL_HARTSEL               (0x3ff << DMI_DMCONTROL_HARTSEL_OFFSET)
+/*
+* This bit controls the reset signal from the DM to the rest of the
+* system. To perform a reset the debugger writes 1, and then writes 0
+* to deassert the reset.
+ */
+#define DMI_DMCONTROL_NDMRESET_OFFSET       1
+#define DMI_DMCONTROL_NDMRESET_LENGTH       1
+#define DMI_DMCONTROL_NDMRESET              (0x1 << DMI_DMCONTROL_NDMRESET_OFFSET)
+/*
+* This bit serves as a reset signal for the Debug Module itself.
+*
+* 0: The module's state, including authentication mechanism,
+* takes its reset values (the \Fdmactive bit is the only bit which can
+* be written to something other than its reset value).
+*
+* 1: The module functions normally.
+*
+* No other mechanism should exist that may result in resetting the
+* Debug Module after power up, including the platform's system reset
+* or Debug Transport reset signals.
+*
+* A debugger should pulse this bit low to ensure that the Debug
+* Module is fully reset and ready to use.
+*
+* Implementations may use this bit to aid debugging, for example by
+* preventing the Debug Module from being power gated while debugging
+* is active.
+ */
+#define DMI_DMCONTROL_DMACTIVE_OFFSET       0
+#define DMI_DMCONTROL_DMACTIVE_LENGTH       1
+#define DMI_DMCONTROL_DMACTIVE              (0x1 << DMI_DMCONTROL_DMACTIVE_OFFSET)
+#define DMI_HARTINFO                        0x12
+/*
+* Number of {\tt dscratch} registers available for the debugger
+* to use during program buffer execution, starting from \Rdscratchzero.
+* The debugger can make no assumptions about the contents of these
+* registers between commands.
+ */
+#define DMI_HARTINFO_NSCRATCH_OFFSET        20
+#define DMI_HARTINFO_NSCRATCH_LENGTH        4
+#define DMI_HARTINFO_NSCRATCH               (0xf << DMI_HARTINFO_NSCRATCH_OFFSET)
+/*
+* 0: The {\tt data} registers are shadowed in the hart by CSR
+* registers. Each CSR register is XLEN bits in size, and corresponds
+* to a single argument, per Table~\ref{tab:datareg}.
+*
+* 1: The {\tt data} registers are shadowed in the hart's memory map.
+* Each register takes up 4 bytes in the memory map.
+ */
+#define DMI_HARTINFO_DATAACCESS_OFFSET      16
+#define DMI_HARTINFO_DATAACCESS_LENGTH      1
+#define DMI_HARTINFO_DATAACCESS             (0x1 << DMI_HARTINFO_DATAACCESS_OFFSET)
+/*
+* If \Fdataaccess is 0: Number of CSR registers dedicated to
+* shadowing the {\tt data} registers.
+*
+* If \Fdataaccess is 1: Number of 32-bit words in the memory map
+* dedicated to shadowing the {\tt data} registers.
+ */
+#define DMI_HARTINFO_DATASIZE_OFFSET        12
+#define DMI_HARTINFO_DATASIZE_LENGTH        4
+#define DMI_HARTINFO_DATASIZE               (0xf << DMI_HARTINFO_DATASIZE_OFFSET)
+/*
+* If \Fdataaccess is 0: The number of the first CSR dedicated to
+* shadowing the {\tt data} registers.
+*
+* If \Fdataaccess is 1: Signed address of RAM where the {\tt data}
+* registers are shadowed.
+ */
+#define DMI_HARTINFO_DATAADDR_OFFSET        0
+#define DMI_HARTINFO_DATAADDR_LENGTH        12
+#define DMI_HARTINFO_DATAADDR               (0xfff << DMI_HARTINFO_DATAADDR_OFFSET)
+#define DMI_HALTSUM                         0x13
+#define DMI_HALTSUM_HALT1023_992_OFFSET     31
+#define DMI_HALTSUM_HALT1023_992_LENGTH     1
+#define DMI_HALTSUM_HALT1023_992            (0x1 << DMI_HALTSUM_HALT1023_992_OFFSET)
+#define DMI_HALTSUM_HALT991_960_OFFSET      30
+#define DMI_HALTSUM_HALT991_960_LENGTH      1
+#define DMI_HALTSUM_HALT991_960             (0x1 << DMI_HALTSUM_HALT991_960_OFFSET)
+#define DMI_HALTSUM_HALT959_928_OFFSET      29
+#define DMI_HALTSUM_HALT959_928_LENGTH      1
+#define DMI_HALTSUM_HALT959_928             (0x1 << DMI_HALTSUM_HALT959_928_OFFSET)
+#define DMI_HALTSUM_HALT927_896_OFFSET      28
+#define DMI_HALTSUM_HALT927_896_LENGTH      1
+#define DMI_HALTSUM_HALT927_896             (0x1 << DMI_HALTSUM_HALT927_896_OFFSET)
+#define DMI_HALTSUM_HALT895_864_OFFSET      27
+#define DMI_HALTSUM_HALT895_864_LENGTH      1
+#define DMI_HALTSUM_HALT895_864             (0x1 << DMI_HALTSUM_HALT895_864_OFFSET)
+#define DMI_HALTSUM_HALT863_832_OFFSET      26
+#define DMI_HALTSUM_HALT863_832_LENGTH      1
+#define DMI_HALTSUM_HALT863_832             (0x1 << DMI_HALTSUM_HALT863_832_OFFSET)
+#define DMI_HALTSUM_HALT831_800_OFFSET      25
+#define DMI_HALTSUM_HALT831_800_LENGTH      1
+#define DMI_HALTSUM_HALT831_800             (0x1 << DMI_HALTSUM_HALT831_800_OFFSET)
+#define DMI_HALTSUM_HALT799_768_OFFSET      24
+#define DMI_HALTSUM_HALT799_768_LENGTH      1
+#define DMI_HALTSUM_HALT799_768             (0x1 << DMI_HALTSUM_HALT799_768_OFFSET)
+#define DMI_HALTSUM_HALT767_736_OFFSET      23
+#define DMI_HALTSUM_HALT767_736_LENGTH      1
+#define DMI_HALTSUM_HALT767_736             (0x1 << DMI_HALTSUM_HALT767_736_OFFSET)
+#define DMI_HALTSUM_HALT735_704_OFFSET      22
+#define DMI_HALTSUM_HALT735_704_LENGTH      1
+#define DMI_HALTSUM_HALT735_704             (0x1 << DMI_HALTSUM_HALT735_704_OFFSET)
+#define DMI_HALTSUM_HALT703_672_OFFSET      21
+#define DMI_HALTSUM_HALT703_672_LENGTH      1
+#define DMI_HALTSUM_HALT703_672             (0x1 << DMI_HALTSUM_HALT703_672_OFFSET)
+#define DMI_HALTSUM_HALT671_640_OFFSET      20
+#define DMI_HALTSUM_HALT671_640_LENGTH      1
+#define DMI_HALTSUM_HALT671_640             (0x1 << DMI_HALTSUM_HALT671_640_OFFSET)
+#define DMI_HALTSUM_HALT639_608_OFFSET      19
+#define DMI_HALTSUM_HALT639_608_LENGTH      1
+#define DMI_HALTSUM_HALT639_608             (0x1 << DMI_HALTSUM_HALT639_608_OFFSET)
+#define DMI_HALTSUM_HALT607_576_OFFSET      18
+#define DMI_HALTSUM_HALT607_576_LENGTH      1
+#define DMI_HALTSUM_HALT607_576             (0x1 << DMI_HALTSUM_HALT607_576_OFFSET)
+#define DMI_HALTSUM_HALT575_544_OFFSET      17
+#define DMI_HALTSUM_HALT575_544_LENGTH      1
+#define DMI_HALTSUM_HALT575_544             (0x1 << DMI_HALTSUM_HALT575_544_OFFSET)
+#define DMI_HALTSUM_HALT543_512_OFFSET      16
+#define DMI_HALTSUM_HALT543_512_LENGTH      1
+#define DMI_HALTSUM_HALT543_512             (0x1 << DMI_HALTSUM_HALT543_512_OFFSET)
+#define DMI_HALTSUM_HALT511_480_OFFSET      15
+#define DMI_HALTSUM_HALT511_480_LENGTH      1
+#define DMI_HALTSUM_HALT511_480             (0x1 << DMI_HALTSUM_HALT511_480_OFFSET)
+#define DMI_HALTSUM_HALT479_448_OFFSET      14
+#define DMI_HALTSUM_HALT479_448_LENGTH      1
+#define DMI_HALTSUM_HALT479_448             (0x1 << DMI_HALTSUM_HALT479_448_OFFSET)
+#define DMI_HALTSUM_HALT447_416_OFFSET      13
+#define DMI_HALTSUM_HALT447_416_LENGTH      1
+#define DMI_HALTSUM_HALT447_416             (0x1 << DMI_HALTSUM_HALT447_416_OFFSET)
+#define DMI_HALTSUM_HALT415_384_OFFSET      12
+#define DMI_HALTSUM_HALT415_384_LENGTH      1
+#define DMI_HALTSUM_HALT415_384             (0x1 << DMI_HALTSUM_HALT415_384_OFFSET)
+#define DMI_HALTSUM_HALT383_352_OFFSET      11
+#define DMI_HALTSUM_HALT383_352_LENGTH      1
+#define DMI_HALTSUM_HALT383_352             (0x1 << DMI_HALTSUM_HALT383_352_OFFSET)
+#define DMI_HALTSUM_HALT351_320_OFFSET      10
+#define DMI_HALTSUM_HALT351_320_LENGTH      1
+#define DMI_HALTSUM_HALT351_320             (0x1 << DMI_HALTSUM_HALT351_320_OFFSET)
+#define DMI_HALTSUM_HALT319_288_OFFSET      9
+#define DMI_HALTSUM_HALT319_288_LENGTH      1
+#define DMI_HALTSUM_HALT319_288             (0x1 << DMI_HALTSUM_HALT319_288_OFFSET)
+#define DMI_HALTSUM_HALT287_256_OFFSET      8
+#define DMI_HALTSUM_HALT287_256_LENGTH      1
+#define DMI_HALTSUM_HALT287_256             (0x1 << DMI_HALTSUM_HALT287_256_OFFSET)
+#define DMI_HALTSUM_HALT255_224_OFFSET      7
+#define DMI_HALTSUM_HALT255_224_LENGTH      1
+#define DMI_HALTSUM_HALT255_224             (0x1 << DMI_HALTSUM_HALT255_224_OFFSET)
+#define DMI_HALTSUM_HALT223_192_OFFSET      6
+#define DMI_HALTSUM_HALT223_192_LENGTH      1
+#define DMI_HALTSUM_HALT223_192             (0x1 << DMI_HALTSUM_HALT223_192_OFFSET)
+#define DMI_HALTSUM_HALT191_160_OFFSET      5
+#define DMI_HALTSUM_HALT191_160_LENGTH      1
+#define DMI_HALTSUM_HALT191_160             (0x1 << DMI_HALTSUM_HALT191_160_OFFSET)
+#define DMI_HALTSUM_HALT159_128_OFFSET      4
+#define DMI_HALTSUM_HALT159_128_LENGTH      1
+#define DMI_HALTSUM_HALT159_128             (0x1 << DMI_HALTSUM_HALT159_128_OFFSET)
+#define DMI_HALTSUM_HALT127_96_OFFSET       3
+#define DMI_HALTSUM_HALT127_96_LENGTH       1
+#define DMI_HALTSUM_HALT127_96              (0x1 << DMI_HALTSUM_HALT127_96_OFFSET)
+#define DMI_HALTSUM_HALT95_64_OFFSET        2
+#define DMI_HALTSUM_HALT95_64_LENGTH        1
+#define DMI_HALTSUM_HALT95_64               (0x1 << DMI_HALTSUM_HALT95_64_OFFSET)
+#define DMI_HALTSUM_HALT63_32_OFFSET        1
+#define DMI_HALTSUM_HALT63_32_LENGTH        1
+#define DMI_HALTSUM_HALT63_32               (0x1 << DMI_HALTSUM_HALT63_32_OFFSET)
+#define DMI_HALTSUM_HALT31_0_OFFSET         0
+#define DMI_HALTSUM_HALT31_0_LENGTH         1
+#define DMI_HALTSUM_HALT31_0                (0x1 << DMI_HALTSUM_HALT31_0_OFFSET)
+#define DMI_HAWINDOWSEL                     0x14
+#define DMI_HAWINDOWSEL_HAWINDOWSEL_OFFSET  0
+#define DMI_HAWINDOWSEL_HAWINDOWSEL_LENGTH  5
+#define DMI_HAWINDOWSEL_HAWINDOWSEL         (0x1f << DMI_HAWINDOWSEL_HAWINDOWSEL_OFFSET)
+#define DMI_HAWINDOW                        0x15
+#define DMI_HAWINDOW_MASKDATA_OFFSET        0
+#define DMI_HAWINDOW_MASKDATA_LENGTH        32
+#define DMI_HAWINDOW_MASKDATA               (0xffffffff << DMI_HAWINDOW_MASKDATA_OFFSET)
+#define DMI_ABSTRACTCS                      0x16
+/*
+* Size of the Program Buffer, in 32-bit words. Valid sizes are 0 - 16.
+*
+* TODO: Explain what can be done with each size of the buffer, to suggest
+* why you would want more or less words.
+ */
+#define DMI_ABSTRACTCS_PROGSIZE_OFFSET      24
+#define DMI_ABSTRACTCS_PROGSIZE_LENGTH      5
+#define DMI_ABSTRACTCS_PROGSIZE             (0x1f << DMI_ABSTRACTCS_PROGSIZE_OFFSET)
+/*
+* 1: An abstract command is currently being executed.
+*
+* This bit is set as soon as \Rcommand is written, and is
+* not cleared until that command has completed.
+ */
+#define DMI_ABSTRACTCS_BUSY_OFFSET          12
+#define DMI_ABSTRACTCS_BUSY_LENGTH          1
+#define DMI_ABSTRACTCS_BUSY                 (0x1 << DMI_ABSTRACTCS_BUSY_OFFSET)
+/*
+* Gets set if an abstract command fails. The bits in this field remain set until
+* they are cleared by writing 1 to them. No abstract command is
+* started until the value is reset to 0.
+*
+* 0 (none): No error.
+*
+* 1 (busy): An abstract command was executing while \Rcommand or one
+* of the {\tt data} registers was accessed.
+*
+* 2 (not supported): The requested command is not supported. A
+* command that is not supported while the hart is running may be
+* supported when it is halted.
+*
+* 3 (exception): An exception occurred while executing the command
+* (eg. while executing the Program Buffer).
+*
+* 4 (halt/resume): An abstract command couldn't execute because the
+* hart wasn't in the expected state (running/halted).
+*
+* 7 (other): The command failed for another reason.
+ */
+#define DMI_ABSTRACTCS_CMDERR_OFFSET        8
+#define DMI_ABSTRACTCS_CMDERR_LENGTH        3
+#define DMI_ABSTRACTCS_CMDERR               (0x7 << DMI_ABSTRACTCS_CMDERR_OFFSET)
+/*
+* Number of {\tt data} registers that are implemented as part of the
+* abstract command interface. Valid sizes are 0 - 8.
+ */
+#define DMI_ABSTRACTCS_DATACOUNT_OFFSET     0
+#define DMI_ABSTRACTCS_DATACOUNT_LENGTH     5
+#define DMI_ABSTRACTCS_DATACOUNT            (0x1f << DMI_ABSTRACTCS_DATACOUNT_OFFSET)
+#define DMI_COMMAND                         0x17
+/*
+* The type determines the overall functionality of this
+* abstract command.
+ */
+#define DMI_COMMAND_CMDTYPE_OFFSET          24
+#define DMI_COMMAND_CMDTYPE_LENGTH          8
+#define DMI_COMMAND_CMDTYPE                 (0xff << DMI_COMMAND_CMDTYPE_OFFSET)
+/*
+* This field is interpreted in a command-specific manner,
+* described for each abstract command.
+ */
+#define DMI_COMMAND_CONTROL_OFFSET          0
+#define DMI_COMMAND_CONTROL_LENGTH          24
+#define DMI_COMMAND_CONTROL                 (0xffffff << DMI_COMMAND_CONTROL_OFFSET)
+#define DMI_ABSTRACTAUTO                    0x18
+/*
+* When a bit in this field is 1, read or write accesses the corresponding {\tt progbuf} word
+* cause the command in \Rcommand to be executed again.
+ */
+#define DMI_ABSTRACTAUTO_AUTOEXECPROGBUF_OFFSET 16
+#define DMI_ABSTRACTAUTO_AUTOEXECPROGBUF_LENGTH 16
+#define DMI_ABSTRACTAUTO_AUTOEXECPROGBUF    (0xffff << DMI_ABSTRACTAUTO_AUTOEXECPROGBUF_OFFSET)
+/*
+* When a bit in this field is 1, read or write accesses the corresponding {\tt data} word
+* cause the command in \Rcommand to be executed again.
+ */
+#define DMI_ABSTRACTAUTO_AUTOEXECDATA_OFFSET 0
+#define DMI_ABSTRACTAUTO_AUTOEXECDATA_LENGTH 12
+#define DMI_ABSTRACTAUTO_AUTOEXECDATA       (0xfff << DMI_ABSTRACTAUTO_AUTOEXECDATA_OFFSET)
+#define DMI_CFGSTRADDR0                     0x19
+#define DMI_CFGSTRADDR0_ADDR_OFFSET         0
+#define DMI_CFGSTRADDR0_ADDR_LENGTH         32
+#define DMI_CFGSTRADDR0_ADDR                (0xffffffff << DMI_CFGSTRADDR0_ADDR_OFFSET)
+#define DMI_CFGSTRADDR1                     0x1a
+#define DMI_CFGSTRADDR2                     0x1b
+#define DMI_CFGSTRADDR3                     0x1c
+#define DMI_DATA0                           0x04
+#define DMI_DATA0_DATA_OFFSET               0
+#define DMI_DATA0_DATA_LENGTH               32
+#define DMI_DATA0_DATA                      (0xffffffff << DMI_DATA0_DATA_OFFSET)
+#define DMI_DATA1                           0x05
+#define DMI_DATA2                           0x06
+#define DMI_DATA3                           0x07
+#define DMI_DATA4                           0x08
+#define DMI_DATA5                           0x09
+#define DMI_DATA6                           0x0a
+#define DMI_DATA7                           0x0b
+#define DMI_DATA8                           0x0c
+#define DMI_DATA9                           0x0d
+#define DMI_DATA10                          0x0e
+#define DMI_DATA11                          0x0f
+#define DMI_PROGBUF0                        0x20
+#define DMI_PROGBUF0_DATA_OFFSET            0
+#define DMI_PROGBUF0_DATA_LENGTH            32
+#define DMI_PROGBUF0_DATA                   (0xffffffff << DMI_PROGBUF0_DATA_OFFSET)
+#define DMI_PROGBUF1                        0x21
+#define DMI_PROGBUF2                        0x22
+#define DMI_PROGBUF3                        0x23
+#define DMI_PROGBUF4                        0x24
+#define DMI_PROGBUF5                        0x25
+#define DMI_PROGBUF6                        0x26
+#define DMI_PROGBUF7                        0x27
+#define DMI_PROGBUF8                        0x28
+#define DMI_PROGBUF9                        0x29
+#define DMI_PROGBUF10                       0x2a
+#define DMI_PROGBUF11                       0x2b
+#define DMI_PROGBUF12                       0x2c
+#define DMI_PROGBUF13                       0x2d
+#define DMI_PROGBUF14                       0x2e
+#define DMI_PROGBUF15                       0x2f
+#define DMI_AUTHDATA                        0x30
+#define DMI_AUTHDATA_DATA_OFFSET            0
+#define DMI_AUTHDATA_DATA_LENGTH            32
+#define DMI_AUTHDATA_DATA                   (0xffffffff << DMI_AUTHDATA_DATA_OFFSET)
+#define DMI_SERCS                           0x34
+/*
+* Number of supported serial ports.
+ */
+#define DMI_SERCS_SERIALCOUNT_OFFSET        28
+#define DMI_SERCS_SERIALCOUNT_LENGTH        4
+#define DMI_SERCS_SERIALCOUNT               (0xf << DMI_SERCS_SERIALCOUNT_OFFSET)
+/*
+* Select which serial port is accessed by \Rserrx and \Rsertx.
+ */
+#define DMI_SERCS_SERIAL_OFFSET             24
+#define DMI_SERCS_SERIAL_LENGTH             3
+#define DMI_SERCS_SERIAL                    (0x7 << DMI_SERCS_SERIAL_OFFSET)
+#define DMI_SERCS_ERROR7_OFFSET             23
+#define DMI_SERCS_ERROR7_LENGTH             1
+#define DMI_SERCS_ERROR7                    (0x1 << DMI_SERCS_ERROR7_OFFSET)
+#define DMI_SERCS_VALID7_OFFSET             22
+#define DMI_SERCS_VALID7_LENGTH             1
+#define DMI_SERCS_VALID7                    (0x1 << DMI_SERCS_VALID7_OFFSET)
+#define DMI_SERCS_FULL7_OFFSET              21
+#define DMI_SERCS_FULL7_LENGTH              1
+#define DMI_SERCS_FULL7                     (0x1 << DMI_SERCS_FULL7_OFFSET)
+#define DMI_SERCS_ERROR6_OFFSET             20
+#define DMI_SERCS_ERROR6_LENGTH             1
+#define DMI_SERCS_ERROR6                    (0x1 << DMI_SERCS_ERROR6_OFFSET)
+#define DMI_SERCS_VALID6_OFFSET             19
+#define DMI_SERCS_VALID6_LENGTH             1
+#define DMI_SERCS_VALID6                    (0x1 << DMI_SERCS_VALID6_OFFSET)
+#define DMI_SERCS_FULL6_OFFSET              18
+#define DMI_SERCS_FULL6_LENGTH              1
+#define DMI_SERCS_FULL6                     (0x1 << DMI_SERCS_FULL6_OFFSET)
+#define DMI_SERCS_ERROR5_OFFSET             17
+#define DMI_SERCS_ERROR5_LENGTH             1
+#define DMI_SERCS_ERROR5                    (0x1 << DMI_SERCS_ERROR5_OFFSET)
+#define DMI_SERCS_VALID5_OFFSET             16
+#define DMI_SERCS_VALID5_LENGTH             1
+#define DMI_SERCS_VALID5                    (0x1 << DMI_SERCS_VALID5_OFFSET)
+#define DMI_SERCS_FULL5_OFFSET              15
+#define DMI_SERCS_FULL5_LENGTH              1
+#define DMI_SERCS_FULL5                     (0x1 << DMI_SERCS_FULL5_OFFSET)
+#define DMI_SERCS_ERROR4_OFFSET             14
+#define DMI_SERCS_ERROR4_LENGTH             1
+#define DMI_SERCS_ERROR4                    (0x1 << DMI_SERCS_ERROR4_OFFSET)
+#define DMI_SERCS_VALID4_OFFSET             13
+#define DMI_SERCS_VALID4_LENGTH             1
+#define DMI_SERCS_VALID4                    (0x1 << DMI_SERCS_VALID4_OFFSET)
+#define DMI_SERCS_FULL4_OFFSET              12
+#define DMI_SERCS_FULL4_LENGTH              1
+#define DMI_SERCS_FULL4                     (0x1 << DMI_SERCS_FULL4_OFFSET)
+#define DMI_SERCS_ERROR3_OFFSET             11
+#define DMI_SERCS_ERROR3_LENGTH             1
+#define DMI_SERCS_ERROR3                    (0x1 << DMI_SERCS_ERROR3_OFFSET)
+#define DMI_SERCS_VALID3_OFFSET             10
+#define DMI_SERCS_VALID3_LENGTH             1
+#define DMI_SERCS_VALID3                    (0x1 << DMI_SERCS_VALID3_OFFSET)
+#define DMI_SERCS_FULL3_OFFSET              9
+#define DMI_SERCS_FULL3_LENGTH              1
+#define DMI_SERCS_FULL3                     (0x1 << DMI_SERCS_FULL3_OFFSET)
+#define DMI_SERCS_ERROR2_OFFSET             8
+#define DMI_SERCS_ERROR2_LENGTH             1
+#define DMI_SERCS_ERROR2                    (0x1 << DMI_SERCS_ERROR2_OFFSET)
+#define DMI_SERCS_VALID2_OFFSET             7
+#define DMI_SERCS_VALID2_LENGTH             1
+#define DMI_SERCS_VALID2                    (0x1 << DMI_SERCS_VALID2_OFFSET)
+#define DMI_SERCS_FULL2_OFFSET              6
+#define DMI_SERCS_FULL2_LENGTH              1
+#define DMI_SERCS_FULL2                     (0x1 << DMI_SERCS_FULL2_OFFSET)
+#define DMI_SERCS_ERROR1_OFFSET             5
+#define DMI_SERCS_ERROR1_LENGTH             1
+#define DMI_SERCS_ERROR1                    (0x1 << DMI_SERCS_ERROR1_OFFSET)
+#define DMI_SERCS_VALID1_OFFSET             4
+#define DMI_SERCS_VALID1_LENGTH             1
+#define DMI_SERCS_VALID1                    (0x1 << DMI_SERCS_VALID1_OFFSET)
+#define DMI_SERCS_FULL1_OFFSET              3
+#define DMI_SERCS_FULL1_LENGTH              1
+#define DMI_SERCS_FULL1                     (0x1 << DMI_SERCS_FULL1_OFFSET)
+/*
+* 1 when the debugger-to-core queue for serial port 0 has
+* over or underflowed. This bit will remain set until it is reset by
+* writing 1 to this bit.
+ */
+#define DMI_SERCS_ERROR0_OFFSET             2
+#define DMI_SERCS_ERROR0_LENGTH             1
+#define DMI_SERCS_ERROR0                    (0x1 << DMI_SERCS_ERROR0_OFFSET)
+/*
+* 1 when the core-to-debugger queue for serial port 0 is not empty.
+ */
+#define DMI_SERCS_VALID0_OFFSET             1
+#define DMI_SERCS_VALID0_LENGTH             1
+#define DMI_SERCS_VALID0                    (0x1 << DMI_SERCS_VALID0_OFFSET)
+/*
+* 1 when the debugger-to-core queue for serial port 0 is full.
+ */
+#define DMI_SERCS_FULL0_OFFSET              0
+#define DMI_SERCS_FULL0_LENGTH              1
+#define DMI_SERCS_FULL0                     (0x1 << DMI_SERCS_FULL0_OFFSET)
+#define DMI_SERTX                           0x35
+#define DMI_SERTX_DATA_OFFSET               0
+#define DMI_SERTX_DATA_LENGTH               32
+#define DMI_SERTX_DATA                      (0xffffffff << DMI_SERTX_DATA_OFFSET)
+#define DMI_SERRX                           0x36
+#define DMI_SERRX_DATA_OFFSET               0
+#define DMI_SERRX_DATA_LENGTH               32
+#define DMI_SERRX_DATA                      (0xffffffff << DMI_SERRX_DATA_OFFSET)
+#define DMI_SBCS                            0x38
+/*
+* When a 1 is written here, triggers a read at the address in {\tt
+* sbaddress} using the access size set by \Fsbaccess.
+ */
+#define DMI_SBCS_SBSINGLEREAD_OFFSET        20
+#define DMI_SBCS_SBSINGLEREAD_LENGTH        1
+#define DMI_SBCS_SBSINGLEREAD               (0x1 << DMI_SBCS_SBSINGLEREAD_OFFSET)
+/*
+* Select the access size to use for system bus accesses triggered by
+* writes to the {\tt sbaddress} registers or \Rsbdatazero.
+*
+* 0: 8-bit
+*
+* 1: 16-bit
+*
+* 2: 32-bit
+*
+* 3: 64-bit
+*
+* 4: 128-bit
+*
+* If an unsupported system bus access size is written here,
+* the DM may not perform the access, or may perform the access
+* with any access size.
+ */
+#define DMI_SBCS_SBACCESS_OFFSET            17
+#define DMI_SBCS_SBACCESS_LENGTH            3
+#define DMI_SBCS_SBACCESS                   (0x7 << DMI_SBCS_SBACCESS_OFFSET)
+/*
+* When 1, the internal address value (used by the system bus master)
+* is incremented by the access size (in bytes) selected in \Fsbaccess
+* after every system bus access.
+ */
+#define DMI_SBCS_SBAUTOINCREMENT_OFFSET     16
+#define DMI_SBCS_SBAUTOINCREMENT_LENGTH     1
+#define DMI_SBCS_SBAUTOINCREMENT            (0x1 << DMI_SBCS_SBAUTOINCREMENT_OFFSET)
+/*
+* When 1, every read from \Rsbdatazero automatically triggers a system
+* bus read at the new address.
+ */
+#define DMI_SBCS_SBAUTOREAD_OFFSET          15
+#define DMI_SBCS_SBAUTOREAD_LENGTH          1
+#define DMI_SBCS_SBAUTOREAD                 (0x1 << DMI_SBCS_SBAUTOREAD_OFFSET)
+/*
+* When the debug module's system bus
+* master causes a bus error, this field gets set. The bits in this
+* field remain set until they are cleared by writing 1 to them.
+* While this field is non-zero, no more system bus accesses can be
+* initiated by the debug module.
+*
+* 0: There was no bus error.
+*
+* 1: There was a timeout.
+*
+* 2: A bad address was accessed.
+*
+* 3: There was some other error (eg. alignment).
+*
+* 4: The system bus master was busy when a one of the
+* {\tt sbaddress} or {\tt sbdata} registers was written,
+* or the {\tt sbdata} register was read when it had
+* stale data.
+ */
+#define DMI_SBCS_SBERROR_OFFSET             12
+#define DMI_SBCS_SBERROR_LENGTH             3
+#define DMI_SBCS_SBERROR                    (0x7 << DMI_SBCS_SBERROR_OFFSET)
+/*
+* Width of system bus addresses in bits. (0 indicates there is no bus
+* access support.)
+ */
+#define DMI_SBCS_SBASIZE_OFFSET             5
+#define DMI_SBCS_SBASIZE_LENGTH             7
+#define DMI_SBCS_SBASIZE                    (0x7f << DMI_SBCS_SBASIZE_OFFSET)
+/*
+* 1 when 128-bit system bus accesses are supported.
+ */
+#define DMI_SBCS_SBACCESS128_OFFSET         4
+#define DMI_SBCS_SBACCESS128_LENGTH         1
+#define DMI_SBCS_SBACCESS128                (0x1 << DMI_SBCS_SBACCESS128_OFFSET)
+/*
+* 1 when 64-bit system bus accesses are supported.
+ */
+#define DMI_SBCS_SBACCESS64_OFFSET          3
+#define DMI_SBCS_SBACCESS64_LENGTH          1
+#define DMI_SBCS_SBACCESS64                 (0x1 << DMI_SBCS_SBACCESS64_OFFSET)
+/*
+* 1 when 32-bit system bus accesses are supported.
+ */
+#define DMI_SBCS_SBACCESS32_OFFSET          2
+#define DMI_SBCS_SBACCESS32_LENGTH          1
+#define DMI_SBCS_SBACCESS32                 (0x1 << DMI_SBCS_SBACCESS32_OFFSET)
+/*
+* 1 when 16-bit system bus accesses are supported.
+ */
+#define DMI_SBCS_SBACCESS16_OFFSET          1
+#define DMI_SBCS_SBACCESS16_LENGTH          1
+#define DMI_SBCS_SBACCESS16                 (0x1 << DMI_SBCS_SBACCESS16_OFFSET)
+/*
+* 1 when 8-bit system bus accesses are supported.
+ */
+#define DMI_SBCS_SBACCESS8_OFFSET           0
+#define DMI_SBCS_SBACCESS8_LENGTH           1
+#define DMI_SBCS_SBACCESS8                  (0x1 << DMI_SBCS_SBACCESS8_OFFSET)
+#define DMI_SBADDRESS0                      0x39
+/*
+* Accesses bits 31:0 of the internal address.
+ */
+#define DMI_SBADDRESS0_ADDRESS_OFFSET       0
+#define DMI_SBADDRESS0_ADDRESS_LENGTH       32
+#define DMI_SBADDRESS0_ADDRESS              (0xffffffff << DMI_SBADDRESS0_ADDRESS_OFFSET)
+#define DMI_SBADDRESS1                      0x3a
+/*
+* Accesses bits 63:32 of the internal address (if the system address
+* bus is that wide).
+ */
+#define DMI_SBADDRESS1_ADDRESS_OFFSET       0
+#define DMI_SBADDRESS1_ADDRESS_LENGTH       32
+#define DMI_SBADDRESS1_ADDRESS              (0xffffffff << DMI_SBADDRESS1_ADDRESS_OFFSET)
+#define DMI_SBADDRESS2                      0x3b
+/*
+* Accesses bits 95:64 of the internal address (if the system address
+* bus is that wide).
+ */
+#define DMI_SBADDRESS2_ADDRESS_OFFSET       0
+#define DMI_SBADDRESS2_ADDRESS_LENGTH       32
+#define DMI_SBADDRESS2_ADDRESS              (0xffffffff << DMI_SBADDRESS2_ADDRESS_OFFSET)
+#define DMI_SBDATA0                         0x3c
+/*
+* Accesses bits 31:0 of the internal data.
+ */
+#define DMI_SBDATA0_DATA_OFFSET             0
+#define DMI_SBDATA0_DATA_LENGTH             32
+#define DMI_SBDATA0_DATA                    (0xffffffff << DMI_SBDATA0_DATA_OFFSET)
+#define DMI_SBDATA1                         0x3d
+/*
+* Accesses bits 63:32 of the internal data (if the system bus is
+* that wide).
+ */
+#define DMI_SBDATA1_DATA_OFFSET             0
+#define DMI_SBDATA1_DATA_LENGTH             32
+#define DMI_SBDATA1_DATA                    (0xffffffff << DMI_SBDATA1_DATA_OFFSET)
+#define DMI_SBDATA2                         0x3e
+/*
+* Accesses bits 95:64 of the internal data (if the system bus is
+* that wide).
+ */
+#define DMI_SBDATA2_DATA_OFFSET             0
+#define DMI_SBDATA2_DATA_LENGTH             32
+#define DMI_SBDATA2_DATA                    (0xffffffff << DMI_SBDATA2_DATA_OFFSET)
+#define DMI_SBDATA3                         0x3f
+/*
+* Accesses bits 127:96 of the internal data (if the system bus is
+* that wide).
+ */
+#define DMI_SBDATA3_DATA_OFFSET             0
+#define DMI_SBDATA3_DATA_LENGTH             32
+#define DMI_SBDATA3_DATA                    (0xffffffff << DMI_SBDATA3_DATA_OFFSET)
+#define SERINFO                             0x280
+/*
+* Like \Fserialzero.
+ */
+#define SERINFO_SERIAL7_OFFSET              7
+#define SERINFO_SERIAL7_LENGTH              1
+#define SERINFO_SERIAL7                     (0x1 << SERINFO_SERIAL7_OFFSET)
+/*
+* Like \Fserialzero.
+ */
+#define SERINFO_SERIAL6_OFFSET              6
+#define SERINFO_SERIAL6_LENGTH              1
+#define SERINFO_SERIAL6                     (0x1 << SERINFO_SERIAL6_OFFSET)
+/*
+* Like \Fserialzero.
+ */
+#define SERINFO_SERIAL5_OFFSET              5
+#define SERINFO_SERIAL5_LENGTH              1
+#define SERINFO_SERIAL5                     (0x1 << SERINFO_SERIAL5_OFFSET)
+/*
+* Like \Fserialzero.
+ */
+#define SERINFO_SERIAL4_OFFSET              4
+#define SERINFO_SERIAL4_LENGTH              1
+#define SERINFO_SERIAL4                     (0x1 << SERINFO_SERIAL4_OFFSET)
+/*
+* Like \Fserialzero.
+ */
+#define SERINFO_SERIAL3_OFFSET              3
+#define SERINFO_SERIAL3_LENGTH              1
+#define SERINFO_SERIAL3                     (0x1 << SERINFO_SERIAL3_OFFSET)
+/*
+* Like \Fserialzero.
+ */
+#define SERINFO_SERIAL2_OFFSET              2
+#define SERINFO_SERIAL2_LENGTH              1
+#define SERINFO_SERIAL2                     (0x1 << SERINFO_SERIAL2_OFFSET)
+/*
+* Like \Fserialzero.
+ */
+#define SERINFO_SERIAL1_OFFSET              1
+#define SERINFO_SERIAL1_LENGTH              1
+#define SERINFO_SERIAL1                     (0x1 << SERINFO_SERIAL1_OFFSET)
+/*
+* 1 means serial interface 0 is supported.
+ */
+#define SERINFO_SERIAL0_OFFSET              0
+#define SERINFO_SERIAL0_LENGTH              1
+#define SERINFO_SERIAL0                     (0x1 << SERINFO_SERIAL0_OFFSET)
+#define SERSEND0                            0x200
+#define SERRECV0                            0x204
+#define SERSTAT0                            0x208
+/*
+* Send ready. 1 when the core-to-debugger queue is not full. 0
+* otherwise.
+ */
+#define SERSTAT0_SENDR_OFFSET               1
+#define SERSTAT0_SENDR_LENGTH               1
+#define SERSTAT0_SENDR                      (0x1 << SERSTAT0_SENDR_OFFSET)
+/*
+* Receive ready. 1 when the debugger-to-core queue is not empty. 0
+* otherwise.
+ */
+#define SERSTAT0_RECVR_OFFSET               0
+#define SERSTAT0_RECVR_LENGTH               1
+#define SERSTAT0_RECVR                      (0x1 << SERSTAT0_RECVR_OFFSET)
+#define SERSEND1                            0x210
+#define SERRECV1                            0x214
+#define SERSTAT1                            0x218
+#define SERSEND2                            0x220
+#define SERRECV2                            0x224
+#define SERSTAT2                            0x228
+#define SERSEND3                            0x230
+#define SERRECV3                            0x234
+#define SERSTAT3                            0x238
+#define SERSEND4                            0x240
+#define SERRECV4                            0x244
+#define SERSTAT4                            0x248
+#define SERSEND5                            0x250
+#define SERRECV5                            0x254
+#define SERSTAT5                            0x258
+#define SERSEND6                            0x260
+#define SERRECV6                            0x264
+#define SERSTAT6                            0x268
+#define SERSEND7                            0x274
+#define SERRECV7                            0x278
+#define SERSTAT7                            0x27c
+#define TRACE                               0x728
+/*
+* 1 if the trace buffer has wrapped since the last time \Fdiscard was
+* written. 0 otherwise.
+ */
+#define TRACE_WRAPPED_OFFSET                24
+#define TRACE_WRAPPED_LENGTH                1
+#define TRACE_WRAPPED                       (0x1 << TRACE_WRAPPED_OFFSET)
+/*
+* Emit Timestamp trace sequences.
+ */
+#define TRACE_EMITTIMESTAMP_OFFSET          23
+#define TRACE_EMITTIMESTAMP_LENGTH          1
+#define TRACE_EMITTIMESTAMP                 (0x1 << TRACE_EMITTIMESTAMP_OFFSET)
+/*
+* Emit Store Data trace sequences.
+ */
+#define TRACE_EMITSTOREDATA_OFFSET          22
+#define TRACE_EMITSTOREDATA_LENGTH          1
+#define TRACE_EMITSTOREDATA                 (0x1 << TRACE_EMITSTOREDATA_OFFSET)
+/*
+* Emit Load Data trace sequences.
+ */
+#define TRACE_EMITLOADDATA_OFFSET           21
+#define TRACE_EMITLOADDATA_LENGTH           1
+#define TRACE_EMITLOADDATA                  (0x1 << TRACE_EMITLOADDATA_OFFSET)
+/*
+* Emit Store Address trace sequences.
+ */
+#define TRACE_EMITSTOREADDR_OFFSET          20
+#define TRACE_EMITSTOREADDR_LENGTH          1
+#define TRACE_EMITSTOREADDR                 (0x1 << TRACE_EMITSTOREADDR_OFFSET)
+/*
+* Emit Load Address trace sequences.
+ */
+#define TRACE_EMITLOADADDR_OFFSET           19
+#define TRACE_EMITLOADADDR_LENGTH           1
+#define TRACE_EMITLOADADDR                  (0x1 << TRACE_EMITLOADADDR_OFFSET)
+/*
+* Emit Privilege Level trace sequences.
+ */
+#define TRACE_EMITPRIV_OFFSET               18
+#define TRACE_EMITPRIV_LENGTH               1
+#define TRACE_EMITPRIV                      (0x1 << TRACE_EMITPRIV_OFFSET)
+/*
+* Emit Branch Taken and Branch Not Taken trace sequences.
+ */
+#define TRACE_EMITBRANCH_OFFSET             17
+#define TRACE_EMITBRANCH_LENGTH             1
+#define TRACE_EMITBRANCH                    (0x1 << TRACE_EMITBRANCH_OFFSET)
+/*
+* Emit PC trace sequences.
+ */
+#define TRACE_EMITPC_OFFSET                 16
+#define TRACE_EMITPC_LENGTH                 1
+#define TRACE_EMITPC                        (0x1 << TRACE_EMITPC_OFFSET)
+/*
+* Determine what happens when the trace buffer is full.  0 means wrap
+* and overwrite. 1 means turn off trace until \Fdiscard is written as 1.
+* 2 means cause a trace full exception. 3 is reserved for future use.
+ */
+#define TRACE_FULLACTION_OFFSET             8
+#define TRACE_FULLACTION_LENGTH             2
+#define TRACE_FULLACTION                    (0x3 << TRACE_FULLACTION_OFFSET)
+/*
+* 0: Trace to a dedicated on-core RAM (which is not further defined in
+* this spec).
+*
+* 1: Trace to RAM on the system bus.
+*
+* 2: Send trace data to a dedicated off-chip interface (which is not
+* defined in this spec). This does not affect execution speed.
+*
+* 3: Reserved for future use.
+*
+* Options 0 and 1 slow down execution (eg. because of system bus
+* contention).
+ */
+#define TRACE_DESTINATION_OFFSET            4
+#define TRACE_DESTINATION_LENGTH            2
+#define TRACE_DESTINATION                   (0x3 << TRACE_DESTINATION_OFFSET)
+/*
+* When 1, the trace logic may stall processor execution to ensure it
+* can emit all the trace sequences required. When 0 individual trace
+* sequences may be dropped.
+ */
+#define TRACE_STALL_OFFSET                  2
+#define TRACE_STALL_LENGTH                  1
+#define TRACE_STALL                         (0x1 << TRACE_STALL_OFFSET)
+/*
+* Writing 1 to this bit tells the trace logic that any trace
+* collected is no longer required. When tracing to RAM, it resets the
+* trace write pointer to the start of the memory, as well as
+* \Fwrapped.
+ */
+#define TRACE_DISCARD_OFFSET                1
+#define TRACE_DISCARD_LENGTH                1
+#define TRACE_DISCARD                       (0x1 << TRACE_DISCARD_OFFSET)
+#define TRACE_SUPPORTED_OFFSET              0
+#define TRACE_SUPPORTED_LENGTH              1
+#define TRACE_SUPPORTED                     (0x1 << TRACE_SUPPORTED_OFFSET)
+#define TBUFSTART                           0x729
+#define TBUFEND                             0x72a
+#define TBUFWRITE                           0x72b
+#define SHORTNAME                           0x123
+/*
+* Description of what this field is used for.
+ */
+#define SHORTNAME_FIELD_OFFSET              0
+#define SHORTNAME_FIELD_LENGTH              8
+#define SHORTNAME_FIELD                     (0xff << SHORTNAME_FIELD_OFFSET)
+#define AC_ACCESS_REGISTER                  None
+/*
+* This is 0 to indicate Access Register Command.
+ */
+#define AC_ACCESS_REGISTER_CMDTYPE_OFFSET   24
+#define AC_ACCESS_REGISTER_CMDTYPE_LENGTH   8
+#define AC_ACCESS_REGISTER_CMDTYPE          (0xff << AC_ACCESS_REGISTER_CMDTYPE_OFFSET)
+/*
+* 2: Access the lowest 32 bits of the register.
+*
+* 3: Access the lowest 64 bits of the register.
+*
+* 4: Access the lowest 128 bits of the register.
+*
+* If \Fsize specifies a size larger than the register's actual size,
+* then the access must fail. If a register is accessible, then reads of \Fsize
+* less than or equal to the register's actual size must be supported.
+ */
+#define AC_ACCESS_REGISTER_SIZE_OFFSET      20
+#define AC_ACCESS_REGISTER_SIZE_LENGTH      3
+#define AC_ACCESS_REGISTER_SIZE             (0x7 << AC_ACCESS_REGISTER_SIZE_OFFSET)
+/*
+* When 1, execute the program in the Program Buffer exactly once
+* before performing the transfer.
+* \textbf{WARNING: preexec is considered for removal.}
+ */
+#define AC_ACCESS_REGISTER_PREEXEC_OFFSET   19
+#define AC_ACCESS_REGISTER_PREEXEC_LENGTH   1
+#define AC_ACCESS_REGISTER_PREEXEC          (0x1 << AC_ACCESS_REGISTER_PREEXEC_OFFSET)
+/*
+* When 1, execute the program in the Program Buffer exactly once
+* after performing the transfer, if any.
+ */
+#define AC_ACCESS_REGISTER_POSTEXEC_OFFSET  18
+#define AC_ACCESS_REGISTER_POSTEXEC_LENGTH  1
+#define AC_ACCESS_REGISTER_POSTEXEC         (0x1 << AC_ACCESS_REGISTER_POSTEXEC_OFFSET)
+/*
+* 0: Don't do the operation specified by \Fwrite.
+*
+* 1: Do the operation specified by \Fwrite.
+ */
+#define AC_ACCESS_REGISTER_TRANSFER_OFFSET  17
+#define AC_ACCESS_REGISTER_TRANSFER_LENGTH  1
+#define AC_ACCESS_REGISTER_TRANSFER         (0x1 << AC_ACCESS_REGISTER_TRANSFER_OFFSET)
+/*
+* When \Ftransfer is set:
+* 0: Copy data from the specified register into {\tt arg0} portion
+* of {\tt data}.
+*
+* 1: Copy data from {\tt arg0} portion of {\tt data} into the
+* specified register.
+ */
+#define AC_ACCESS_REGISTER_WRITE_OFFSET     16
+#define AC_ACCESS_REGISTER_WRITE_LENGTH     1
+#define AC_ACCESS_REGISTER_WRITE            (0x1 << AC_ACCESS_REGISTER_WRITE_OFFSET)
+/*
+* Number of the register to access, as described in Table~\ref{tab:regno}.
+ */
+#define AC_ACCESS_REGISTER_REGNO_OFFSET     0
+#define AC_ACCESS_REGISTER_REGNO_LENGTH     16
+#define AC_ACCESS_REGISTER_REGNO            (0xffff << AC_ACCESS_REGISTER_REGNO_OFFSET)
+#define AC_QUICK_ACCESS                     None
+/*
+* This is 1 to indicate Quick Access command.
+ */
+#define AC_QUICK_ACCESS_CMDTYPE_OFFSET      24
+#define AC_QUICK_ACCESS_CMDTYPE_LENGTH      8
+#define AC_QUICK_ACCESS_CMDTYPE             (0xff << AC_QUICK_ACCESS_CMDTYPE_OFFSET)

--- a/fesvr/dtm.cc
+++ b/fesvr/dtm.cc
@@ -1,4 +1,5 @@
 #include "dtm.h"
+#include "debug_defines.h"
 #include "encoding.h"
 #include <stdlib.h>
 #include <stdio.h>
@@ -30,16 +31,23 @@
 #define ADDI(dst, src, imm) (0x13 | ((dst) << 7) | ((src) << 15) | (uint32_t)ENCODE_ITYPE_IMM(imm))
 #define SRL(dst, src, sh) (0x5033 | ((dst) << 7) | ((src) << 15) | ((sh) << 20))
 #define FENCE_I 0x100f
+#define EBREAK  0x00100073
 #define X0 0
 #define S0 8
 #define S1 9
+
+#define AC_AR_REGNO(x) ((0x1000 | x) << AC_ACCESS_REGISTER_REGNO_OFFSET)
+#define AC_AR_SIZE(x)  ((x == 64 ? 3 : 2) << AC_ACCESS_REGISTER_SIZE_OFFSET)
 
 #define WRITE 1
 #define SET 2
 #define CLEAR 3
 #define CSRRx(type, dst, csr, src) (0x73 | ((type) << 12) | ((dst) << 7) | ((src) << 15) | (uint32_t)((csr) << 20))
 
-uint64_t dtm_t::do_command(dtm_t::req r)
+#define get_field(reg, mask) (((reg) & (mask)) / ((mask) & ~((mask) << 1)))
+#define set_field(reg, mask, val) (((reg) & ~(mask)) | (((val) * ((mask) & ~((mask) << 1))) & (mask)))
+
+uint32_t dtm_t::do_command(dtm_t::req r)
 {
   req_buf = r;
   target->switch_to();
@@ -47,12 +55,12 @@ uint64_t dtm_t::do_command(dtm_t::req r)
   return resp_buf.data;
 }
 
-uint64_t dtm_t::read(uint32_t addr)
+uint32_t dtm_t::read(uint32_t addr)
 {
   return do_command((req){addr, 1, 0});
 }
 
-uint64_t dtm_t::write(uint32_t addr, uint64_t data)
+uint32_t dtm_t::write(uint32_t addr, uint32_t data)
 {
   return do_command((req){addr, 2, data});
 }
@@ -62,55 +70,77 @@ void dtm_t::nop()
   do_command((req){0, 0, 0});
 }
 
-uint32_t dtm_t::run_program(const uint32_t program[], size_t n, size_t result)
+void dtm_t::halt()
 {
-  // MW many changes here.
-  // I'm writing this assuming you would just use the program
-  // buffer implementation and not use the 'abstract command'
-  // to transfer data. At least that is what this function should mean.
-  
-  assert(n <= ram_words());
-  assert(result < ram_words());
+  write(DMI_DMCONTROL, DMI_DMCONTROL_HALTREQ);
+  while(get_field(read(DMI_DMSTATUS), DMI_DMSTATUS_ALLHALTED) == 0);
+}
 
-  // MW -- no longer use the 34-bit data with interrupt bit.
-  // write the program into progbuf, then write COMMAND register
-  // to make it happen.
-  //uint64_t interrupt_bit = 0x200000000U;
-  for (size_t i = 0; i < n; i++)
-    write(DMI_PROGBUF0 + i, program[i]);//
-
-  // The current code halted and resumed the hart for every single one of
-  // these accesses. This seems pretty inefficient, but here is what you'd have to do to get the same effect.
-  // (The spec has a "quick access" command which isn't currently implemented that does more of the
-  // old behavior. But I'm still wondering if that's what you really wanted to do anyway for e.g. a
-  // big code download.
-  write(DMI_DMCONTROL, DMCONTROL_HALTREQ);
-  // wait for the hart to actually halt
-  while ((read(DMI_DMCONTROL) & DMI_DMCONTROL_ALLHALTED) == 0);
-  // Your current program assumes that you can just use s0 and s1.
-  // You either need to rewrite those snippets to save s0 and s1 somewhere,
-  // or save them here
+void dtm_t::resume(){
   
-  // Make it execute the program
-  write(DMI_COMMAND, AC_ACCESS_REGISTER_POSTEXEC); // This just executes program buffer without doing anything else.    //| (i == n-1 ? interrupt_bit : 0));
-  // wait for not busy. ROM no longer handles
-  // putting error codes into the RAM automatically
-  uint32_t abstractcs;
-  do { abstractcs = read(DMI_ABSTRACTCS) }
-  while (abstractcs & DMI_ABSTRACTCS_BUSY);
-  if (abstractcs & DMI_ABSTRACTCS_CMDERR) {
-    //handle error e.g. exception
+  write(DMI_DMCONTROL, DMI_DMCONTROL_RESUMEREQ);
+  while (get_field(read(DMI_DMSTATUS), DMI_DMSTATUS_ALLRUNNING) == 0); 
+}
+
+uint64_t dtm_t::save_reg(unsigned regno){
+
+  uint32_t data[xlen/(8*4)];
+  uint32_t command = AC_ACCESS_REGISTER_TRANSFER | AC_AR_SIZE(xlen) | AC_AR_REGNO(regno);
+  run_abstract_command(command, 0, 0, data, xlen / (8*4)); 
+  uint64_t result = data[0];
+  if (xlen > 32) {
+    result |= ((uint64_t)data[1]) << 32;
+  }
+  return result;
+}
+
+void dtm_t::restore_reg(unsigned regno, uint64_t val) {
+
+  uint32_t data[xlen/(8*4)];
+  data[0] = (uint32_t) val;
+  if (xlen > 32) {
+    data[1] = (uint32_t) (val >> 32);
   }
 
-  uint64_t rdata = read(DMI_PROGBUF0 + result);
-
-  // You would need to restore s0 and s1 here given your current program.
+  uint32_t command = AC_ACCESS_REGISTER_TRANSFER |
+    AC_ACCESS_REGISTER_WRITE |
+    AC_AR_SIZE(xlen) |
+    AC_AR_REGNO(regno);
   
-  // Resume the hart
-  write (DMI_COMMAND, DMCONTROL_RESUMEREQ);
-  // wait for it to be running
-  while ((read(DMI_DMCONTROL) & DMI_CONTROL_ALLRUNNING == 0);
-  return uint32_t rdata;
+  run_abstract_command(command, 0, 0, data, xlen / (8*4)); 
+
+}
+
+uint32_t dtm_t::run_abstract_command(uint32_t command,
+                                     const uint32_t program[], size_t program_n,
+                                     uint32_t data[], size_t data_n)
+{
+  
+  assert(program_n <= ram_words);
+  assert(data_n    <= data_words);
+  
+  for (size_t i = 0; i < program_n; i++) {
+    write(DMI_PROGBUF0 + i, program[i]);
+  }
+  
+  for (size_t i = 0; i < data_n; i++) {
+    write(DMI_DATA0 + i, data[i]);
+  }
+  
+  write(DMI_COMMAND, command);
+  
+  // Wait for not busy and then check for error.
+  uint32_t abstractcs;
+  do {
+    abstractcs = read(DMI_ABSTRACTCS);
+  } while (abstractcs & DMI_ABSTRACTCS_BUSY);
+  
+  for (size_t i = 0; i < data_n; i++){
+    data[i] = read(DMI_DATA0 + i);
+  }
+  
+  return get_field(abstractcs, DMI_ABSTRACTCS_CMDERR);
+
 }
 
 size_t dtm_t::chunk_align()
@@ -120,85 +150,142 @@ size_t dtm_t::chunk_align()
 
 void dtm_t::read_chunk(uint64_t taddr, size_t len, void* dst)
 {
-  uint32_t prog[ram_words()];
-  uint32_t res[ram_words()];
-  int result_word = 2 + (len / (xlen/8)) * 2;
-  int addr_word = result_word;
-  int prog_words = addr_word + (xlen/32);
+  uint32_t prog[ram_words];
+  uint32_t data[data_words];
 
-  // This is what I mean about the abstract command.
-  // Since progbuf_base is not really specified, you can
-  // replace it with the abstract command way of doing this
-  // to generate this instruction.
+  uint8_t * curr = (uint8_t*) dst;
 
-  // Also, the Debug ROM used to automatically save s0 and s1 for you.
-  // That is no longer the case. If your program uses those registers,
-  // then you need to save them either within this program or
-  // before calling this function.
+  halt();
 
-  // Also, we need to actually halt and resume the hart somewhere.
-  // What is calling these functions? Do we really want to halt
-  // and resume the hart for every one of these accesses?
+  uint64_t s0 = save_reg(S0);
+  uint64_t s1 = save_reg(S1);
   
+  prog[0] = LOAD(xlen, S1, S0, 0);
+  prog[1] = ADDI(S0, S0, xlen/8);
+  prog[2] = EBREAK;
 
-  prog[0] = LOAD(xlen, S0, X0, ram_base() + addr_word * 4);
-  for (size_t i = 0; i < len/(xlen/8); i++) {
-    prog[2*i+1] = LOAD(xlen, S1, S0, i * (xlen/8));
-    prog[2*i+2] = STORE(xlen, S1, X0, ram_base() + (result_word * 4) + (i * (xlen/8)));
+  data[0] = (uint32_t) taddr;
+  if (xlen > 32) {
+    data[1] = (uint32_t) (taddr >> 32);
   }
-  // MW this should just be ebreak now, that is how you indicate the end of the program.
-  prog[result_word - 1] = EBREAK;//JUMP(rom_ret(), ram_base() + (result_word - 1) * 4);
-  prog[addr_word] = (uint32_t)taddr;
-  prog[addr_word + 1] = (uint32_t)(taddr >> 32);
 
-  res[0] = run_program(prog, prog_words, result_word);
-  for (size_t i = 1; i < len/4; i++)
-    res[i] = read(result_word + i);
-  memcpy(dst, res, len);
+  // Write s0 with the address, then execute program buffer.
+  // This will get S1 with the data and increment s0.
+  uint32_t command = AC_ACCESS_REGISTER_TRANSFER |
+    AC_ACCESS_REGISTER_WRITE |
+    AC_ACCESS_REGISTER_POSTEXEC |
+    AC_AR_SIZE(xlen) | 
+    AC_AR_REGNO(S0);
+
+  run_abstract_command (command, prog, 3, data, xlen/(4*8));
+
+  // TODO: could use autoexec here.
+  for (size_t i = 0; i < len / (xlen/(4)); i++){
+    command = AC_ACCESS_REGISTER_TRANSFER |
+      AC_ACCESS_REGISTER_POSTEXEC |
+      AC_AR_SIZE(xlen) |
+      AC_AR_REGNO(S1);
+    run_abstract_command(command, 0, 0, data, xlen/(4*8));
+
+    memcpy(curr, data, xlen/8);
+    curr += xlen/8;
+  }
+
+  restore_reg(S0, s0);
+  restore_reg(S1, s1);
+
+  resume();
+  
 }
 
 void dtm_t::write_chunk(uint64_t taddr, size_t len, const void* src)
 {
-  uint32_t prog[ram_words()];
-  int data_word = 2 + (len / (xlen/8)) * 2;
-  int addr_word = data_word + len/4;
-  int prog_words = addr_word + (xlen/32);
 
-  prog[0] = LOAD(xlen, S0, X0, ram_base() + addr_word * 4);
-  for (size_t i = 0; i < len/(xlen/8); i++) {
-    prog[2*i+1] = LOAD(xlen, S1, X0, ram_base() + (data_word * 4) + (i * (xlen/8)));
-    prog[2*i+2] = STORE(xlen, S1, S0, i * (xlen/8));
+  uint32_t prog[ram_words];
+  uint32_t data[data_words];
+
+  const uint8_t * curr = (const uint8_t*) src;
+
+  halt();
+  uint64_t s0 = save_reg(S0);
+  uint64_t s1 = save_reg(S1);
+  
+  prog[0] = STORE(xlen, S1, S0, 0);
+  prog[1] = ADDI(S0, S0, xlen/8);
+  prog[2] = EBREAK;
+
+  data[0] = (uint32_t) taddr;
+  if (xlen > 32) {
+    data[1] = (uint32_t) (taddr >> 32);
   }
-  prog[data_word - 1] = EBREAK; //JUMP(rom_ret(), ram_base() + (data_word - 1)*4);
-  memcpy(prog + data_word, src, len);
-  prog[addr_word] = (uint32_t)taddr;
-  prog[addr_word + 1] = (uint32_t)(taddr >> 32);
 
-  run_program(prog, prog_words, data_word);
+  // Write s0 with the address.
+  uint32_t command = AC_ACCESS_REGISTER_TRANSFER |
+    AC_ACCESS_REGISTER_WRITE |
+    AC_AR_SIZE(xlen) |
+    AC_AR_REGNO(S0);
+  run_abstract_command (command, prog, 3, data, xlen/(4*8));
+
+  // TODO: could use autoexec here.
+  for (size_t i = 0; i < len / (xlen/8); i++){
+    command = AC_ACCESS_REGISTER_TRANSFER |
+      AC_ACCESS_REGISTER_POSTEXEC |
+      AC_AR_SIZE(xlen) |
+      AC_AR_REGNO(S1);
+    run_abstract_command(command, 0, 0, data, xlen/(4*8));
+
+    memcpy(data, curr, xlen/8);
+    curr += xlen/8;
+    
+  }
+
+  restore_reg(S0, s0);
+  restore_reg(S1, s1);
+
+  resume();
+
 }
 
 void dtm_t::clear_chunk(uint64_t taddr, size_t len)
 {
-  uint32_t prog[ram_words()];
-  int addr1_word = 6;
-  int addr2_word = addr1_word + (xlen/32);
-  int prog_words = addr2_word + (xlen/32);
+  uint32_t prog[ram_words];
+  uint32_t data[data_words];
+  
+  halt();
+  uint64_t s0 = save_reg(S0);
+  uint64_t s1 = save_reg(S1);
 
-  if (prog_words + (xlen/32) > ram_words())
-    return htif_t::clear_chunk(taddr, len);
+  uint32_t command;
 
-  prog[0] = LOAD(xlen, S0, X0, ram_base() + addr1_word * 4);
-  prog[1] = LOAD(xlen, S1, X0, ram_base() + addr2_word * 4);
-  prog[2] = STORE(xlen, X0, S0, 0);
-  prog[3] = ADDI(S0, S0, xlen/8);
-  prog[4] = BNE(S0, S1, 2*4, 4*4);
-  prog[5] = JUMP(rom_ret(), ram_base() + 5*4);
-  prog[addr1_word] = (uint32_t)taddr;
-  prog[addr1_word + 1] = (uint32_t)(taddr >> 32);
-  prog[addr2_word] = (uint32_t)(taddr + len);
-  prog[addr2_word + 1] = (uint32_t)((taddr + len) >> 32);
+  // S0 = Addr
+  data[0] = (uint32_t) taddr;
+  data[1] = (uint32_t) (taddr >> 32);
+  command = AC_ACCESS_REGISTER_TRANSFER |
+    AC_ACCESS_REGISTER_WRITE |
+    AC_AR_SIZE(xlen) |
+    AC_AR_REGNO(S0);
+  run_abstract_command(command, 0, 0, data, xlen/(4*8)); 
 
-  run_program(prog, prog_words, 0);
+  // S1 = Addr + len, loop until S0 = S1
+  prog[0] = STORE(xlen, X0, S0, 0);
+  prog[1] = ADDI(S0, S0, xlen/8);
+  prog[2] = BNE(S0, S1, 0*4, 2*4);
+  prog[3] = EBREAK;
+
+  data[0] = (uint32_t) (taddr + len);
+  data[1] = (uint32_t) ((taddr + len) >> 32);
+  command = AC_ACCESS_REGISTER_TRANSFER |
+    AC_ACCESS_REGISTER_WRITE |
+    AC_AR_SIZE(xlen) |
+    AC_AR_REGNO(S1)  |
+    AC_ACCESS_REGISTER_POSTEXEC;
+  run_abstract_command(command, prog, 4, data, xlen/(4*8)); 
+
+  restore_reg(S0, s0);
+  restore_reg(S1, s1);
+
+  resume();
+  
 }
 
 uint64_t dtm_t::write_csr(unsigned which, uint64_t data)
@@ -223,57 +310,87 @@ uint64_t dtm_t::read_csr(unsigned which)
 
 uint64_t dtm_t::modify_csr(unsigned which, uint64_t data, uint32_t type)
 {
-  int data_word = 4;
-  int prog_words = data_word + xlen/32;
+  
+  halt();
+  
   uint32_t prog[] = {
-    LOAD(xlen, S0, X0, ram_base() + data_word * 4),
+    // Save S0 so we can use it.
+    CSRRx(WRITE, S0, CSR_DSCRATCH, S0),
+    LOAD(xlen, S0, X0, data_base),
     CSRRx(type, S0, which, S0),
-    STORE(xlen, S0, X0, ram_base() + data_word * 4),
-    EBREAK(),//JUMP(rom_ret(), ram_base() + 12),
-    (uint32_t)data,
-    (uint32_t)(data >> 32)
+    STORE(xlen, S0, X0, data_base),
+    CSRRx(WRITE, S0, CSR_DSCRATCH, S0),
+    EBREAK
   };
 
-  uint64_t res = run_program(prog, prog_words, data_word);
+  uint32_t adata[] = {(uint32_t) data,
+                      (uint32_t) (data >> 32)};
+  
+  uint32_t command = AC_ACCESS_REGISTER_POSTEXEC;
+  
+  run_abstract_command (command, prog, sizeof(prog) / sizeof(*prog), adata, xlen/(4*8));
+  
+  uint64_t res = adata[0];
   if (xlen == 64)
-    res |= read(data_word + 1) << 32;
-  return res;
+    res |= ((uint64_t) adata[1]) << 32;
+  
+  resume();
+  return res;  
+
 }
 
 size_t dtm_t::chunk_max_size()
 {
-  if (xlen == 32)
-    return 4 * ((ram_words() - 4) / 3);
-  else
-    return 8 * ((ram_words() - 6) / 4);
+  // Arbitrary choice. 4k Page size seems reasonable.
+  return 4096;
+
 }
 
 uint32_t dtm_t::get_xlen()
 {
-  const uint32_t prog[] = {
-    CSRRx(SET, S0, CSR_MISA, X0),
-    ADDI(S1, X0, 62),
-    SRL(S0, S0, S1),
-    STORE(32, S0, X0, ram_base()),
-    EBREAK//JUMP(rom_ret(), ram_base() + 16)
-  };
+  // Attempt to read S0 to find out what size it is.
+  // You could also attempt to run code, but you need to save registers
+  // to do that anyway. If what you really want to do is figure out
+  // the size of S0 so you can save it later, then do that.
+  uint32_t command = AC_ACCESS_REGISTER_TRANSFER | AC_AR_REGNO(S0);
+  uint32_t cmderr;
+  
+  const uint32_t prog[] = {};
+  uint32_t data[] = {};
 
-  uint32_t result = run_program(prog, sizeof(prog)/sizeof(*prog), 0);
-  if (result < 2)
-    return 32;
-  else if (result == 2)
+  cmderr = run_abstract_command(command | AC_AR_SIZE(128), prog, 0, data, 0);
+  if (cmderr == 0){
+    // We don't currently support 128 bit.
+    abort();
+    return 128;
+  }
+  write(DMI_ABSTRACTCS, DMI_ABSTRACTCS_CMDERR);
+
+  cmderr = run_abstract_command(command | AC_AR_SIZE(64), prog, 0, data, 0);
+  if (cmderr == 0){
     return 64;
+  }
+  write(DMI_ABSTRACTCS, DMI_ABSTRACTCS_CMDERR);
+
+  cmderr = run_abstract_command(command | AC_AR_SIZE(32), prog, 0, data, 0);
+  if (cmderr == 0){
+    return 32;
+  }
+
   abort();
+  
 }
 
 void dtm_t::fence_i()
 {
   const uint32_t prog[] = {
     FENCE_I,
-    EBREAK,//JUMP(rom_ret(), ram_base() + 4)
+    EBREAK
   };
 
-  run_program(prog, sizeof(prog)/sizeof(*prog), 0);
+  uint32_t command = AC_ACCESS_REGISTER_POSTEXEC;
+  run_abstract_command(command, prog, sizeof(prog)/sizeof(*prog), 0, 0);
+
 }
 
 void host_thread_main(void* arg)
@@ -284,9 +401,12 @@ void host_thread_main(void* arg)
 void dtm_t::reset()
 {
   fence_i();
-  // set pc and un-halt
+  // set pc. Each of these functions already
+  // does a halt and resume.
   write_csr(0x7b1, 0x80000000U);
-  clear_csr(0x7b0, 8);
+
+  //Do we want reset to actually reset the whole system?
+  
 }
 
 void dtm_t::idle()
@@ -297,13 +417,17 @@ void dtm_t::idle()
 
 void dtm_t::producer_thread()
 {
-  // halt hart
-  dminfo = -1U;
-  xlen = 32;
-  set_csr(0x7b0, 8);
 
-  // query hart
-  dminfo = read(0x11);
+  uint32_t abstractcs = read(DMI_ABSTRACTCS);
+  ram_words = get_field(abstractcs, DMI_ABSTRACTCS_PROGSIZE);
+  data_words = get_field(abstractcs, DMI_ABSTRACTCS_DATACOUNT);
+
+  uint32_t hartinfo = read(DMI_HARTINFO);
+  assert(get_field(hartinfo, DMI_HARTINFO_NSCRATCH) > 1);
+  assert(get_field(hartinfo, DMI_HARTINFO_DATAACCESS));
+
+  data_base = get_field(hartinfo, DMI_HARTINFO_DATAADDR);
+  
   xlen = get_xlen();
 
   htif_t::run();

--- a/fesvr/dtm.cc
+++ b/fesvr/dtm.cc
@@ -270,7 +270,7 @@ void dtm_t::die(uint32_t cmderr)
     "HALT/RESUME"
   };
   const char * msg;
-  if (cmderr <= (sizeof(codes) / sizeof(*codes))){
+  if (cmderr < (sizeof(codes) / sizeof(*codes))){
     msg = codes[cmderr];
   } else {
     msg = "OTHER";

--- a/fesvr/dtm.h
+++ b/fesvr/dtm.h
@@ -38,6 +38,7 @@ class dtm_t : public htif_t
     resp  resp_bits
   );
 
+  
   bool req_valid() { return req_wait; }
   req req_bits() { return req_buf; }
   bool resp_ready() { return true; }
@@ -68,6 +69,7 @@ class dtm_t : public htif_t
   uint32_t run_abstract_command(uint32_t command, const uint32_t program[], size_t program_n,
                                 uint32_t data[], size_t data_n);
 
+  void die();
   void halt();
   void resume();
   uint64_t save_reg(unsigned regno);

--- a/fesvr/dtm.h
+++ b/fesvr/dtm.h
@@ -69,7 +69,7 @@ class dtm_t : public htif_t
   uint32_t run_abstract_command(uint32_t command, const uint32_t program[], size_t program_n,
                                 uint32_t data[], size_t data_n);
 
-  void die();
+  void die(uint32_t cmderr);
   void halt();
   void resume();
   uint64_t save_reg(unsigned regno);

--- a/fesvr/dtm.h
+++ b/fesvr/dtm.h
@@ -20,14 +20,16 @@ class dtm_t : public htif_t
   struct req {
     uint32_t addr;
     uint32_t op;
+    // MW: This is only 32 bits now vs 34, but probably fine to keep it as 64
     uint64_t data;
   };
 
   struct resp {
     uint32_t resp;
+    // MW: Again only 32 bits now
     uint64_t data;
   };
-
+  
   void tick(
     bool  req_ready,
     bool  resp_valid,
@@ -65,7 +67,8 @@ class dtm_t : public htif_t
   req req_buf;
   resp resp_buf;
 
-  uint32_t run_program(const uint32_t program[], size_t n, size_t result);
+  uint32_t run_program(const uint32_t program[], size_t n, uint8_t result);
+  
   uint64_t modify_csr(unsigned which, uint64_t data, uint32_t type);
 
   void read_chunk(addr_t taddr, size_t len, void* dst) override;
@@ -79,13 +82,46 @@ class dtm_t : public htif_t
   bool req_wait;
   bool resp_wait;
   uint32_t dminfo;
+  // [MW] some information you may need is in abstractcs register
+  uint32_t abstractcs;
+  
   uint32_t xlen;
 
   static const int max_idle_cycles = 10000;
 
-  size_t ram_base() { return 0x400; }
-  size_t rom_ret() { return 0x804; }
-  size_t ram_words() { return ((dminfo >> 10) & 63) + 1; }
+  // [MW] These addresses aren't defined in the spec
+  // anymore. There are ways to figure them out e.g. at
+  // start up by reading some registers or running programs.
+  // Also, you might want to distinguish between ram_base,
+  // which is basically the old ram_base, and "data_base", which
+  // is for data transfer only. You could just ignore data_base and
+  // do everything through ram_base as this code is currently doing,
+  // or you can use the "abstract commands" to do the data transfer to GPRs
+  // which basically means you don't need to figure out any
+  // of these addresses.
+  
+  // Depending how generic you want this to be, 
+  // you might want to determine these by querying the implementation
+  // vs hard-coding them here, or by using abstract commands you don't even
+  // need these.
+  // You can determine this by running doing aiupc to s0, then using the abstract
+  // command to transfer it out. But, again you probably don't even need to
+  // know this if you do use abstract command.
+  size_t ram_base()  { return 0x400; }
+
+  // MW you can read this in hartinfo.
+  size_t data_base() { return 0x400; }
+  
+  // MW you don't need this anymore. Use ebreak to indicate end of programs.
+  // Debugger has to explicitly tell the hart to resume, it can't resume itself
+  // by executing code like this anymore.
+  //size_t rom_ret()  { return 0x804; }
+
+  // [MW] Updated this to match current spec
+  //size_t ram_words() { return ((dminfo >> 10) & 63) + 1; }
+  size_t ram_words() { return ((abstractcs >> 24) & 0x1F) }
+  size_t data_words()    { return ((abstractcs >> 0)  & 0xF) }
+                                  
   uint32_t get_xlen();
   uint64_t do_command(dtm_t::req r);
 


### PR DESCRIPTION
This just adds some notes about what would need to change to work with Debug spec v13. 

The major issues:

-- ram_base, rom_base aren't defined in the spec. You can figure them out or write your program snippets in a way that doesn't use them.

-- The current code halts and resumes the hart for every low level operation. This is pretty inefficient and I'm wondering if that is the real intention. 

-- the ROM isn't in the spec anymore so you can't assume that s0 and s1 are saved for you before you do run_program. You need to save/restore them within your program, or save them in the debugger by reading them out before doing the run_program you actually care about.

-- You can decide whether you want to use abstract_commands to transfer values to/from GPRs. This might be simpler than trying to do everything within one run_program execution.