### PR TITLE
DTM: Start all Harts

### DIFF
--- a/fesvr/dtm.cc
+++ b/fesvr/dtm.cc
@@ -89,8 +89,9 @@ int dtm_t::enumerate_harts() {
   while(1) {
     select_hart(hartsel);
     dmstatus = read(DMI_DMSTATUS);
-    if (get_field(dmstatus, DMI_DMSTATUS_ANYNONEXISTENT));
-    break;
+    if (get_field(dmstatus, DMI_DMSTATUS_ANYNONEXISTENT)) { 
+      break;
+    }
     hartsel++; 
   }
   return hartsel;

--- a/fesvr/dtm.h
+++ b/fesvr/dtm.h
@@ -71,6 +71,9 @@ class dtm_t : public htif_t
 
   void die(uint32_t cmderr);
   void halt();
+  void select_hart(int);
+  int halt_all_harts();
+  void resume_all_harts();
   void resume();
   uint64_t save_reg(unsigned regno);
   void restore_reg(unsigned regno, uint64_t val);
@@ -95,6 +98,7 @@ class dtm_t : public htif_t
 
   size_t ram_words;
   size_t data_words;
+  int num_harts;
 
   uint32_t get_xlen();
   uint32_t do_command(dtm_t::req r);

--- a/fesvr/dtm.h
+++ b/fesvr/dtm.h
@@ -70,11 +70,10 @@ class dtm_t : public htif_t
                                 uint32_t data[], size_t data_n);
 
   void die(uint32_t cmderr);
-  void halt();
+  void halt(int);
+  int enumerate_harts();
   void select_hart(int);
-  int halt_all_harts();
-  void resume_all_harts();
-  void resume();
+  void resume(int);
   uint64_t save_reg(unsigned regno);
   void restore_reg(unsigned regno, uint64_t val);
   
@@ -99,7 +98,8 @@ class dtm_t : public htif_t
   size_t ram_words;
   size_t data_words;
   int num_harts;
-
+  int current_hart;
+  
   uint32_t get_xlen();
   uint32_t do_command(dtm_t::req r);
 


### PR DESCRIPTION
Previously DTM only used hart 0. This now uses hart 0 for the memory accesses, but actually starts all harts by setting their $pc to _start and letting them resume (DTM probes to find out the number of harts).

Note that this code requires/assumes that all harts have the same XLEN as hart 0. If you don't think that's a good requirement, the code can be easily changed to support heterogenous XLENs, but it will take more simulation cycles.

This PR also updates debug_defines.h to match the current Debug Spec (https://github.com/riscv/riscv-debug-spec/commit/920ec9a69054aba8d69b2acfd06c067798e4c8d8)