### PR TITLE
ignore arguments that start with +

### DIFF
--- a/fesvr/htif.cc
+++ b/fesvr/htif.cc
@@ -246,8 +246,11 @@ void htif_t::parse_arguments(int argc, char ** argv)
           optarg = optarg + 8;
         }
         else {
-          optind--;
-          goto done_processing;
+          if(arg.find("+") != 0) {
+            optind--;
+            goto done_processing;
+          }
+          break;
         }
         goto retry;
       }


### PR DESCRIPTION
This causes htif to skip unknown arguments that start with `+`.

Other arguments that start with `-` will still issue stderr messages but not stop option parsing.

This is an improvement on current handling where htif will silently treat unknown arguments that start with `+` as target arguments.

Open to suggestions but this is a strawman for handling https://github.com/freechipsproject/rocket-chip/issues/1194
