### PR TITLE
Decouple memif_t and htif_t.

### DIFF
--- a/fesvr/htif.h
+++ b/fesvr/htif.h
@@ -9,7 +9,7 @@
 #include <string.h>
 #include <vector>
 
-class htif_t
+class htif_t : public chunked_memif_t
 {
  public:
   htif_t();

--- a/fesvr/htif_hexwriter.cc
+++ b/fesvr/htif_hexwriter.cc
@@ -5,7 +5,7 @@
 #include "htif_hexwriter.h"
 
 htif_hexwriter_t::htif_hexwriter_t(size_t b, size_t w, size_t d)
-  : htif_t(), base(b), width(w), depth(d)
+  : base(b), width(w), depth(d)
 {
 }
 

--- a/fesvr/htif_hexwriter.h
+++ b/fesvr/htif_hexwriter.h
@@ -6,9 +6,9 @@
 #include <map>
 #include <vector>
 #include <stdlib.h>
-#include "htif.h"
+#include "memif.h"
 
-class htif_hexwriter_t : public htif_t
+class htif_hexwriter_t : public chunked_memif_t
 {
 public:
   htif_hexwriter_t(size_t b, size_t w, size_t d);
@@ -21,10 +21,10 @@ protected:
 
   void read_chunk(addr_t taddr, size_t len, void* dst);
   void write_chunk(addr_t taddr, size_t len, const void* src);
+  void clear_chunk(addr_t taddr, size_t len) {}
 
   size_t chunk_max_size() { return width; }
   size_t chunk_align() { return width; }
-  void reset() {}
 
   friend std::ostream& operator<< (std::ostream&, const htif_hexwriter_t&);
 };

--- a/fesvr/memif.h
+++ b/fesvr/memif.h
@@ -10,11 +10,21 @@ typedef uint64_t reg_t;
 typedef int64_t sreg_t;
 typedef reg_t addr_t;
 
-class htif_t;
+class chunked_memif_t
+{
+public:
+  virtual void read_chunk(addr_t taddr, size_t len, void* dst) = 0;
+  virtual void write_chunk(addr_t taddr, size_t len, const void* src) = 0;
+  virtual void clear_chunk(addr_t taddr, size_t len) = 0;
+
+  virtual size_t chunk_align() = 0;
+  virtual size_t chunk_max_size() = 0;
+};
+
 class memif_t
 {
 public:
-  memif_t(htif_t* _htif) : htif(_htif) {}
+  memif_t(chunked_memif_t* _cmemif) : cmemif(_cmemif) {}
   virtual ~memif_t(){}
 
   // read and write byte arrays
@@ -46,7 +56,7 @@ public:
   virtual void write_int64(addr_t addr, int64_t val);
 
 protected:
-  htif_t* htif;
+  chunked_memif_t* cmemif;
 };
 
 #endif // __MEMIF_H


### PR DESCRIPTION
Define a chunked_memif_t interface that serves memif_t, and is implemented by htif_t and htif_hexwriter.  This allows the use of memif_t without needing to bring in htif_t.

This eases the implementation of alternative top-level simulators.  See also riscv/riscv-isa-sim#174