### PR TITLE
[proposal] Fix argument parsing for fesvr under VCS (+permissive/+permissive-off, help text, etc.)

### DIFF
--- a/fesvr/htif.cc
+++ b/fesvr/htif.cc
@@ -203,12 +203,11 @@ void htif_t::parse_arguments(int argc, char ** argv)
   while (1) {
     static struct option long_options[] = { HTIF_LONG_OPTIONS };
     int option_index = 0;
-    int c = getopt_long(argc, argv, "-c:", long_options, &option_index);
+    int c = getopt_long(argc, argv, "-", long_options, &option_index);
 
     if (c == -1) break;
  retry:
     switch (c) {
-      case '?': break;
       case HTIF_LONG_OPTIONS_OPTIND:
         if (optarg) dynamic_devices.push_back(new rfb_t(atoi(optarg)));
         else        dynamic_devices.push_back(new rfb_t);
@@ -224,6 +223,10 @@ void htif_t::parse_arguments(int argc, char ** argv)
       case HTIF_LONG_OPTIONS_OPTIND + 3:
         syscall_proxy.set_chroot(optarg);
         break;
+      case '?':
+        if (permissive)
+          break;
+        throw std::invalid_argument("Unknown argument (did you mean to enable +permissive parsing?)");
       case 1: {
         std::string arg = optarg;
         if (arg == "+rfb") {
@@ -260,12 +263,6 @@ void htif_t::parse_arguments(int argc, char ** argv)
         }
         goto retry;
       }
-        // Special case non-standard VCS options that should be ignored
-      case 'c': // e.g., '-cm line+cond'
-        if (!strcmp(optarg, "m"))
-          optind++;
-        else
-          throw std::invalid_argument("Expected 'm' to follow VCS special case '-c' option");
     }
   }
 

--- a/fesvr/htif.cc
+++ b/fesvr/htif.cc
@@ -302,7 +302,7 @@ void htif_t::usage(const char * program_name)
   fputs("\
 Run a BINARY on the Rocket Chip emulator.\n\
 \n\
-Mandatory arguments to long optiosn are mandatory for short options too.\n\
+Mandatory arguments to long options are mandatory for short options too.\n\
 \n\
 EMULATOR OPTIONS\n\
   Consult emulator.cc if using Verilator or VCS documentation if using VCS\n\

--- a/fesvr/htif.cc
+++ b/fesvr/htif.cc
@@ -199,6 +199,7 @@ int htif_t::exit_code()
 void htif_t::parse_arguments(int argc, char ** argv)
 {
   optind = 0; // reset optind as HTIF may run getopt _after_ others
+  bool permissive = false;
   while (1) {
     static struct option long_options[] = { HTIF_LONG_OPTIONS };
     int option_index = 0;
@@ -245,9 +246,17 @@ void htif_t::parse_arguments(int argc, char ** argv)
           c = HTIF_LONG_OPTIONS_OPTIND + 3;
           optarg = optarg + 8;
         }
+        else if (arg.find("+permissive") == 0) {
+          permissive = true;
+          break;
+        }
         else {
-          optind--;
-          goto done_processing;
+          if (permissive)
+            break;
+          else {
+            optind--;
+            goto done_processing;
+          }
         }
         goto retry;
       }
@@ -264,7 +273,7 @@ done_processing:
   while (optind < argc)
     targs.push_back(argv[optind++]);
   if (!targs.size()) {
-    throw std::invalid_argument("No binary specified for host");
+    throw std::invalid_argument("No binary specified (Did you forget it? Did you forget '--' if running with +permissive?)");
   }
 }
 

--- a/fesvr/htif.h
+++ b/fesvr/htif.h
@@ -76,6 +76,7 @@ class htif_t
        +plus-arg-equivalent\n\
  */
 #define HTIF_USAGE_OPTIONS "HOST OPTIONS\n\
+       +permissive         Ignore any unknown following options\n\
       --rfb=DISPLAY        Add new remote frame buffer on display DISPLAY\n\
        +rfb=DISPLAY          to be accessible on 5900 + DISPLAY (default = 0)\n\
       --signature=FILE     Write torture test signature to FILE\n\

--- a/fesvr/htif.h
+++ b/fesvr/htif.h
@@ -46,6 +46,7 @@ class htif_t
  private:
   void parse_arguments(int argc, char ** argv);
   void register_devices();
+  void usage(const char * program_name);
 
   memif_t mem;
   reg_t entry;
@@ -75,8 +76,13 @@ class htif_t
   -x, --long-option        Description with max 80 characters --------------->\n\
        +plus-arg-equivalent\n\
  */
-#define HTIF_USAGE_OPTIONS "HOST OPTIONS\n\
-       +permissive         Ignore any unknown following options\n\
+#define HTIF_USAGE_OPTIONS \
+"HOST OPTIONS\n\
+  -h, --help               Display this help and exit\n\
+       +permissive         The host will ignore any unparsed options up until\n\
+                             +permissive-off (Only needed for VCS)\n\
+       +permissive-off     Stop ignoring options. This is mandatory if using\n\
+                             +permissive (Only needed for VCS)\n\
       --rfb=DISPLAY        Add new remote frame buffer on display DISPLAY\n\
        +rfb=DISPLAY          to be accessible on 5900 + DISPLAY (default = 0)\n\
       --signature=FILE     Write torture test signature to FILE\n\
@@ -94,6 +100,7 @@ TARGET (RISC-V BINARY) OPTIONS\n\
 
 #define HTIF_LONG_OPTIONS_OPTIND 1024
 #define HTIF_LONG_OPTIONS                                               \
+{"help",      no_argument,       0, 'h'                          },     \
 {"rfb",       optional_argument, 0, HTIF_LONG_OPTIONS_OPTIND     },     \
 {"disk",      required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 1 },     \
 {"signature", required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 2 },     \


### PR DESCRIPTION
Alternative to #41.

This adds one additional option for HTIF: `+permissive`. 

Normally, HTIF will treat the first option that it doesn't understand as the target binary. This works for `emulator.cc` where we control all option parsing, but not for VCS which has a slew of options that are entirely out of our control. E.g., the VCS argument `+verbose` will get treated as the binary.

When `+permissive` is turned on, any subsequent options will be parsed "permissively." This means that anything that HTIF doesn't understand it ignores. This should cover the entirety of all possible VCS options which have any number of odd formats. See Appendix C here: http://www.cerc.utexas.edu/~deronliu/vlsi1/lab3/2014_fall_VLSI_I/LAB3_Website/lab3a/vcs_tutorial.pdf.

This introduces a problem in that HTIF needs to then know what the binary is supposed to be. We could introduce another option (`+permissive-off`) which would turn off permissive parsing. However, I think the cleanest approach is to use the getopt-understood `--` for specifying the end of options. VCS throws a warning for this as it doesn't understand it, but that should be okay. Using an explicit plus-arg (the above `+permissive-off`) would avoid this.

This results in a VCS built emulator call of:
```
./emulator +permissive [ARG...] -- BINARY [BINARY ARG...]
```

@colinschmidt: thoughts?

Personally, I'd prefer to keep the non-permissive parsing as the default as it avoids user errors (my errors), e.g., my misspelled command line arguments don't get swallowed.

Todo:
  - [x] Decide on `+permissive-on` / `+permissive-off` vs. `+permissive` / `--`
  - [x] Rocket Chip PR to update vsim/Make*: https://github.com/freechipsproject/rocket-chip/pull/1266