### PR TITLE
fix compile error for clang

### DIFF
--- a/fesvr/memif.cc
+++ b/fesvr/memif.cc
@@ -1,5 +1,6 @@
 // See LICENSE for license details.
 
+#include <algorithm>
 #include <stdlib.h>
 #include <string.h>
 #include <stdexcept>


### PR DESCRIPTION
The algorithm header is needed in order to use std::min and such.