### PR TITLE
Use $target_alias for TARGET_DIR if set

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,9 @@ declared the RISCV environment variable to point to the RISC-V install path:
 
     $ mkdir build
     $ cd build
-    $ ../configure --prefix=$RISCV
+    $ ../configure --prefix=$RISCV --target=riscv64-unknown-elf
     $ make install
+
+The `--target` flag is optional and defaults to `riscv64-unknown-elf`. The
+target is used to determine the location of loaded programs (e.g. `pk`), so it
+should match the host that `pk` runs on.

--- a/configure
+++ b/configure
@@ -3891,6 +3891,11 @@ CFLAGS="-Wall -O2"
 CXXFLAGS="-Wall -O2 -std=c++11"
 
 
+if test "x$target_alias" != x; then
+  CFLAGS="$CFLAGS -DTARGET_ARCH=\\\"$target_alias\\\""
+  CXXFLAGS="$CXXFLAGS -DTARGET_ARCH=\\\"$target_alias\\\""
+fi
+
 #-------------------------------------------------------------------------
 # MCPPBS subproject list
 #-------------------------------------------------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -71,6 +71,11 @@ AC_HEADER_STDC
 AC_SUBST([CFLAGS],  ["-Wall -O2"])
 AC_SUBST([CXXFLAGS],["-Wall -O2 -std=c++11"])
 
+if test "x$target_alias" != x; then
+  CFLAGS="$CFLAGS -DTARGET_ARCH=\\\"$target_alias\\\""
+  CXXFLAGS="$CXXFLAGS -DTARGET_ARCH=\\\"$target_alias\\\""
+fi
+
 #-------------------------------------------------------------------------
 # MCPPBS subproject list
 #-------------------------------------------------------------------------


### PR DESCRIPTION
The fesvr always looks for `pk` in `riscv64-unknown-elf/bin` - however, for a 32-bit `pk` it is in `riscv32-unknown-elf/bin`. This commit defines `TARGET_ARCH` (used in `fesvr/htif.cc`) based on the value of the `--target` flag if it is provided to `configure`. This makes it a bit easier to use Spike / fesvr/ pk for riscv32, as there doesn't seem to be any other straightforward way of telling fesvr where to look for `pk`.

I've tested this with toolchain builds for both `riscv32-unknown-elf` and `riscv64-unknown-elf`, and haven't come across any issues with it.