### PR TITLE
Decouple the HTIF devices from htif, since they only need the memory interface of htif.

### DIFF
--- a/fesvr/device.h
+++ b/fesvr/device.h
@@ -7,16 +7,16 @@
 #include <string>
 #include <functional>
 
-class htif_t;
+class memif_t;
 
 class command_t
 {
  public:
   typedef std::function<void(uint64_t)> callback_t;
-  command_t(htif_t* htif, uint64_t tohost, callback_t cb)
-    : _htif(htif), tohost(tohost), cb(cb) {}
+  command_t(memif_t& memif, uint64_t tohost, callback_t cb)
+    : _memif(memif), tohost(tohost), cb(cb) {}
 
-  htif_t* htif() { return _htif; }
+  memif_t& memif() { return _memif; }
   uint8_t device() { return tohost >> 56; }
   uint8_t cmd() { return tohost >> 48; }
   uint64_t payload() { return tohost << 16 >> 16; }
@@ -26,7 +26,7 @@ class command_t
   static const size_t MAX_DEVICES = 256;
 
  private:
-  htif_t* _htif;
+  memif_t& _memif;
   uint64_t tohost;
   callback_t cb;
 };

--- a/fesvr/htif.cc
+++ b/fesvr/htif.cc
@@ -169,7 +169,7 @@ int htif_t::run()
   {
     if (auto tohost = mem.read_uint64(tohost_addr)) {
       mem.write_uint64(tohost_addr, 0);
-      command_t cmd(this, tohost, fromhost_callback);
+      command_t cmd(mem, tohost, fromhost_callback);
       device_list.handle_command(cmd);
     } else {
       idle();

--- a/fesvr/rfb.cc
+++ b/fesvr/rfb.cc
@@ -1,5 +1,5 @@
 #include "rfb.h"
-#include "htif.h"
+#include "memif.h"
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sched.h>
@@ -225,6 +225,6 @@ void rfb_t::handle_set_address(command_t cmd)
   addr = cmd.payload();
   if (addr % FB_ALIGN != 0)
     throw std::runtime_error("rfb address must be " + std::to_string(FB_ALIGN) + "-byte aligned");
-  memif = &cmd.htif()->memif();
+  memif = &cmd.memif();
   cmd.respond(1);
 }


### PR DESCRIPTION
This allows simulators to reuse the htif device model without needing htif itself.