### PR TITLE
[dtm] Update target context on switch to host

### DIFF
--- a/fesvr/dtm.cc
+++ b/fesvr/dtm.cc
@@ -613,11 +613,14 @@ void dtm_t::tick(
     resp_wait = false;
 
     resp_buf = resp_bits;
+    // update the target with the current context
+    target = context_t::current();
     host.switch_to();
   }
 }
 
 void dtm_t::return_resp(resp resp_bits){
   resp_buf = resp_bits;
+  target = context_t::current();
   host.switch_to();
 }


### PR DESCRIPTION
In a multi-threaded simulation environment (e.g.: verilator > 4.00) the DPI calling client can change between construction time and the time debug tick is called. If the target is not updated `switch_to()` will potentially end up dereferencing null pointers. Assuming that the DPI call itself is not called multiple times by the simulator, checking that the context is up-to-data should be sufficient. 

 