### PR TITLE
[htif,elfloader] Add an option to skip target memory loading

### DIFF
--- a/fesvr/elf2hex.cc
+++ b/fesvr/elf2hex.cc
@@ -40,7 +40,7 @@ int main(int argc, char** argv)
   htif_hexwriter_t htif(base, width, depth);
   memif_t memif(&htif);
   reg_t entry;
-  load_elf(argv[3], &memif, &entry);
+  load_elf(argv[3], &memif, &entry, true);
   std::cout << htif;
 
   return 0;

--- a/fesvr/elfloader.cc
+++ b/fesvr/elfloader.cc
@@ -14,7 +14,7 @@
 #include <vector>
 #include <map>
 
-std::map<std::string, uint64_t> load_elf(const char* fn, memif_t* memif, reg_t* entry)
+std::map<std::string, uint64_t> load_elf(const char* fn, memif_t* memif, reg_t* entry, bool skiploadmem)
 {
   int fd = open(fn, O_RDONLY);
   struct stat s;
@@ -43,10 +43,12 @@ std::map<std::string, uint64_t> load_elf(const char* fn, memif_t* memif, reg_t* 
       if(ph[i].p_type == PT_LOAD && ph[i].p_memsz) { \
         if (ph[i].p_filesz) { \
           assert(size >= ph[i].p_offset + ph[i].p_filesz); \
-          memif->write(ph[i].p_paddr, ph[i].p_filesz, (uint8_t*)buf + ph[i].p_offset); \
+          if (!skiploadmem) \
+            memif->write(ph[i].p_paddr, ph[i].p_filesz, (uint8_t*)buf + ph[i].p_offset); \
         } \
         zeros.resize(ph[i].p_memsz - ph[i].p_filesz); \
-        memif->write(ph[i].p_paddr + ph[i].p_filesz, ph[i].p_memsz - ph[i].p_filesz, &zeros[0]); \
+        if (!skiploadmem) \
+          memif->write(ph[i].p_paddr + ph[i].p_filesz, ph[i].p_memsz - ph[i].p_filesz, &zeros[0]); \
       } \
     } \
     shdr_t* sh = (shdr_t*)(buf + eh->e_shoff); \

--- a/fesvr/elfloader.h
+++ b/fesvr/elfloader.h
@@ -8,6 +8,6 @@
 #include <string>
 
 class memif_t;
-std::map<std::string, uint64_t> load_elf(const char* fn, memif_t* memif, reg_t* entry);
+std::map<std::string, uint64_t> load_elf(const char* fn, memif_t* memif, reg_t* entry, bool skiploadmem);
 
 #endif

--- a/fesvr/htif.cc
+++ b/fesvr/htif.cc
@@ -99,7 +99,7 @@ void htif_t::load_program()
         "could not open " + targs[0] +
         " (did you misspell it? If VCS, did you forget +permissive/+permissive-off?)");
 
-  std::map<std::string, uint64_t> symbols = load_elf(path.c_str(), &mem, &entry);
+  std::map<std::string, uint64_t> symbols = load_elf(path.c_str(), &mem, &entry, skiploadmem);
 
   if (symbols.count("tohost") && symbols.count("fromhost")) {
     tohost_addr = symbols["tohost"];
@@ -226,6 +226,9 @@ void htif_t::parse_arguments(int argc, char ** argv)
       case HTIF_LONG_OPTIONS_OPTIND + 3:
         syscall_proxy.set_chroot(optarg);
         break;
+      case HTIF_LONG_OPTIONS_OPTIND + 4:
+        skiploadmem = true;
+        break;
       case '?':
         if (!opterr)
           break;
@@ -251,6 +254,10 @@ void htif_t::parse_arguments(int argc, char ** argv)
         else if (arg.find("+chroot=") == 0) {
           c = HTIF_LONG_OPTIONS_OPTIND + 3;
           optarg = optarg + 8;
+        }
+        else if (arg == "+skiploadmem") {
+          c = HTIF_LONG_OPTIONS_OPTIND + 4;
+          optarg = nullptr;
         }
         else if (arg.find("+permissive-off") == 0) {
           if (opterr)

--- a/fesvr/htif.h
+++ b/fesvr/htif.h
@@ -60,6 +60,7 @@ class htif_t : public chunked_memif_t
   addr_t fromhost_addr;
   int exitcode;
   bool stopped;
+  bool skiploadmem;
 
   device_list_t device_list;
   syscall_t syscall_proxy;
@@ -89,6 +90,7 @@ class htif_t : public chunked_memif_t
        +signature=FILE\n\
       --chroot=PATH        Use PATH as location of syscall-servicing binaries\n\
        +chroot=PATH\n\
+      --skiploadmem        Skip loading the target memory \n\
 \n\
 HOST OPTIONS (currently unsupported)\n\
       --disk=DISK          Add DISK device. Use a ramdisk since this isn't\n\
@@ -99,12 +101,13 @@ TARGET (RISC-V BINARY) OPTIONS\n\
   microprocessor.\n"
 
 #define HTIF_LONG_OPTIONS_OPTIND 1024
-#define HTIF_LONG_OPTIONS                                               \
-{"help",      no_argument,       0, 'h'                          },     \
-{"rfb",       optional_argument, 0, HTIF_LONG_OPTIONS_OPTIND     },     \
-{"disk",      required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 1 },     \
-{"signature", required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 2 },     \
-{"chroot",    required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 3 },     \
+#define HTIF_LONG_OPTIONS                                                  \
+{"help",         no_argument,       0, 'h'                          },     \
+{"rfb",          optional_argument, 0, HTIF_LONG_OPTIONS_OPTIND     },     \
+{"disk",         required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 1 },     \
+{"signature",    required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 2 },     \
+{"chroot",       required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 3 },     \
+{"skiploadmem",  optional_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 4 },     \
 {0, 0, 0, 0}
 
 #endif // __HTIF_H

--- a/fesvr/htif.h
+++ b/fesvr/htif.h
@@ -107,7 +107,7 @@ TARGET (RISC-V BINARY) OPTIONS\n\
 {"disk",         required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 1 },     \
 {"signature",    required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 2 },     \
 {"chroot",       required_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 3 },     \
-{"skiploadmem",  optional_argument, 0, HTIF_LONG_OPTIONS_OPTIND + 4 },     \
+{"skiploadmem",  no_argument,       0, HTIF_LONG_OPTIONS_OPTIND + 4 },     \
 {0, 0, 0, 0}
 
 #endif // __HTIF_H


### PR DESCRIPTION
Adds an option to htif which allows emulators to skip target memory loading. Useful for implementations that can load memory image snapshots. 