### PR TITLE
Support HTIFs that are aware of memory preloading

### DIFF
--- a/fesvr/htif.h
+++ b/fesvr/htif.h
@@ -43,6 +43,10 @@ class htif_t : public chunked_memif_t
 
   reg_t get_entry_point() { return entry; }
 
+  // indicates that the initial program load can skip writing this address
+  // range to memory, because it has already been loaded through a sideband
+  virtual bool is_address_preloaded(addr_t taddr, size_t len) { return false; }
+
  private:
   void parse_arguments(int argc, char ** argv);
   void register_devices();


### PR DESCRIPTION
This is an alternative to #53; see that PR for context.

@ccelio @ss2783 this is a sketch of my idea.  Some comments:

- To use this, just override the `is_address_preloaded` method, perhaps just to `return true;`.
- I think it works as-is, but please try it out before approving the PR.
- I only override `write` because I know that's all `load_elf` calls, but it would still be correct if it called something else.
- If an ELF section spans a region that is partially preloaded but partially not, this implementation will conservatively write the whole thing.  I doubt this will manifest in practice.