### PR TITLE
DTM: Leverage WARLness of hartsel to skip nonexistent harts

### DIFF
--- a/fesvr/dtm.cc
+++ b/fesvr/dtm.cc
@@ -84,15 +84,17 @@ void dtm_t::select_hart(int hartsel) {
 }
 
 int dtm_t::enumerate_harts() {
-  int dmstatus;
-  int hartsel = 0;
-  while(1) {
+  int max_hart = (1 << DMI_DMCONTROL_HARTSEL_LENGTH) - 1;
+  write(DMI_DMCONTROL, set_field(read(DMI_DMCONTROL), DMI_DMCONTROL_HARTSEL, max_hart));
+  read(DMI_DMSTATUS);
+  max_hart = get_field(read(DMI_DMCONTROL), DMI_DMCONTROL_HARTSEL);
+
+  int hartsel;
+  for (hartsel = 0; hartsel <= max_hart; hartsel++) {
     select_hart(hartsel);
-    dmstatus = read(DMI_DMSTATUS);
-    if (get_field(dmstatus, DMI_DMSTATUS_ANYNONEXISTENT)) { 
+    int dmstatus = read(DMI_DMSTATUS);
+    if (get_field(dmstatus, DMI_DMSTATUS_ANYNONEXISTENT))
       break;
-    }
-    hartsel++; 
   }
   return hartsel;
 }


### PR DESCRIPTION
The old code relies upon hartsel being able to hold invalid values, so that dmstatus.anynonexistent will go high.  But if hartsel is incapable of holding invalid values (e.g. because it is hardwired to 0), then this code will try to enumerate up to 1K harts (and might not terminate).  Fix by seeing how many bits of hartsel are implemented.